### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 
 A Model Context Protocol (MCP) server implementation that connects Large Language Models (LLMs) to GIS operations using GIS libraries (Currently Shapely and PyProj supported), enabling AI assistants to perform geospatial operations and transformations.
 
+<a href="https://glama.ai/mcp/servers/@mahdin75/gis-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mahdin75/gis-mcp/badge" alt="GIS Server MCP server" />
+</a>
+
 > Alpha
 >
 > Version 0.2.0 (Alpha) is under active development. We welcome contributions and developers to join us in building this project.


### PR DESCRIPTION
This PR adds a badge for the [GIS MCP Server](https://glama.ai/mcp/servers/@mahdin75/gis-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@mahdin75/gis-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mahdin75/gis-mcp/badge" alt="GIS Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.