### PR TITLE
Add Satellite Imagery & Land Cover Tools + Documentation

### DIFF
--- a/docs/data-gathering/README.md
+++ b/docs/data-gathering/README.md
@@ -7,5 +7,7 @@ Currently covered:
 - Climate (via `cdsapi`)
 - Ecology (via `pygbif`)
 - Movement (via `osmnx`)
+- Satellite Imagery (via `pystac-client`)
+- Land Cover (via `pystac-client`)
 
 Each page lists requirements, parameters, and natural-language usage examples you can paste into Claude Desktop.

--- a/docs/data-gathering/land_cover.md
+++ b/docs/data-gathering/land_cover.md
@@ -1,0 +1,62 @@
+### Land Cover (WorldCover & NDVI via `pystac-client`)
+
+The **Land Cover** tool in GIS-MCP allows you to access global land cover maps and vegetation indices through the [Microsoft Planetary Computer](https://planetarycomputer.microsoft.com/).  
+It currently supports downloading ESA **WorldCover** layers and computing **NDVI** from Sentinel-2 imagery.
+
+
+---
+
+#### Installation
+
+To enable land products, install GIS-MCP with the **land-cover** extra:
+
+
+```bash
+pip install gis-mcp[land-cover]
+```
+
+#### Parameters
+
+
+##### `download_worldcover`
+
+- **year** – Year of the WorldCover dataset (e.g., `2020`, `2021`, `2023`).  
+- **collection** *(optional)* – STAC collection ID.  
+  *(default: `"esa-worldcover"`)*  
+- **asset_key** – Asset key to download.  
+  *(default: `"map"`)*  
+- **bbox** *(optional)* – Bounding box string `"minx,miny,maxx,maxy"` in WGS84.  
+- **geometry_geojson** *(optional)* – GeoJSON geometry (string) for clipping.  
+- **out_crs** *(optional)* – Output CRS (e.g., `"EPSG:4326"`).  
+  *(default: `"EPSG:4326"`)*  
+- **filename** *(optional)* – Custom filename for the GeoTIFF.  
+  *(default: auto-generated)*  
+- **path** *(optional)* – Output directory.  
+  *(default: `./data/land_products` inside the package)*  
+
+---
+
+##### `compute_s2_ndvi`
+
+- **datetime** – Date or date range in ISO 8601.  
+  Examples:  
+  - `"2024-07-05"` → single day  
+  - `"2024-07-01/2024-07-15"` → date interval  
+  *(default: `"2024-07-01/2024-07-15"`)*  
+- **cloud_cover_lt** – Maximum cloud cover percentage.  
+  Use `None` to disable filtering.  
+  *(default: `20`)*  
+- **bbox** *(optional)* – Bounding box string `"minx,miny,maxx,maxy"` in WGS84.  
+- **geometry_geojson** *(optional)* – GeoJSON geometry (string) for clipping.  
+- **out_crs** *(optional)* – Output CRS (e.g., `"EPSG:4326"`).  
+  *(default: `"EPSG:4326"`)*  
+- **filename** *(optional)* – Custom filename for the output GeoTIFF.  
+  *(default: auto-generated)*  
+- **path** *(optional)* – Output directory.  
+  *(default: `./data/land_products` inside the package)*  
+
+#### Example Usage
+
+```bash
+Using gis-mcp compute the NDVI from Sentinel-2 imagery over Iran during July 2024 with less than 20% cloud cover.
+```

--- a/docs/data-gathering/satellite_imagery.md
+++ b/docs/data-gathering/satellite_imagery.md
@@ -1,0 +1,58 @@
+### Satellite Imagery (Microsoft Planetary Computer via `pystac-client`)
+
+The **Satellite Imagery** tool in GIS-MCP enables downloading analysis-ready satellite scenes (e.g., Sentinel-2, Landsat) directly from the [Microsoft Planetary Computer](https://planetarycomputer.microsoft.com/).  
+It automatically selects the least-cloudy image matching your search criteria and prepares a multi-band GeoTIFF.
+
+---
+
+#### Installation
+
+To enable satellite imagery downloads, install GIS-MCP with the **satellite-imagery** extra:
+
+```bash
+pip install gis-mcp[satellite-imagery]
+```
+
+#### Parameters
+
+- **collection** – STAC collection ID (e.g., `"sentinel-2-l2a"`, `"landsat-8-c2-l2"`)  
+  *(default: `"sentinel-2-l2a"`)* 
+
+- **assets** – Bands or asset keys to download (list or comma-separated string).  
+  Common Sentinel-2 keys:  
+  - `B04` → Red  
+  - `B03` → Green  
+  - `B02` → Blue  
+  - `B08` → Near Infrared (NIR)  
+  *(default: `["B04","B03","B02"]`)*  
+
+- **datetime** – Date or date range in ISO 8601.  
+  Examples:  
+  - `"2025-08-05"` → single day  
+  - `"2025-08-01/2025-08-31"` → range  
+  *(default: `"2024-01-01/2024-12-31"`)  
+
+- **cloud_cover_lt** – Maximum cloud cover percentage (integer).  
+  Use `None` to disable filtering.  
+  *(default: `20`)*  
+
+- **bbox** *(optional)* – Bounding box string `"minx,miny,maxx,maxy"` in WGS84 coordinates.  
+
+- **geometry_geojson** *(optional)* – A GeoJSON geometry (string).  
+  If provided, the image is clipped precisely to this geometry.  
+
+- **out_crs** *(optional)* – Target CRS for output (e.g., `"EPSG:4326"`).  
+  If omitted, the asset’s native CRS is preserved.  
+
+- **filename** *(optional)* – Custom filename for the output GeoTIFF.  
+  *(default: auto-generated from collection, item ID, and asset keys)*  
+
+- **path** *(optional)* – Output directory.  
+  *(default: `./data/satellite_imagery` inside the package)*
+
+
+#### Example Usage
+
+```bash
+Using gis-mcp download Sentinel-2 RGB imagery for Iran during August 2025 with less than 15% cloud cover.
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,14 @@ satellite-imagery = [
     "requests>=2.31",
 ]
 
+land-cover = [
+    "pystac-client>=0.7.6",
+    "planetary-computer>=1.0.0",
+    "xarray>=2023.1.0",
+    "stackstac>=0.5.0",
+    "requests>=2.31",
+]
+
 all = [
     "pygadm>=0.5.0",
     "cdsapi==0.7.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,11 +62,24 @@ movement = [
     "osmnx>=2.0.0"
 ]
 
+satellite-imagery = [
+    "pystac-client>=0.7.6",
+    "planetary-computer>=1.0.0",
+    "xarray>=2023.1.0",
+    "stackstac>=0.5.0",
+    "requests>=2.31",
+]
+
 all = [
     "pygadm>=0.5.0",
     "cdsapi==0.7.6",
     "pygbif>=0.6.4",
-    "osmnx>=2.0.0"
+    "osmnx>=2.0.0",
+    "pystac-client>=0.7.6",
+    "planetary-computer>=1.0.0",
+    "xarray>=2023.1.0",
+    "stackstac>=0.5.0",
+    "requests>=2.31",
 ]
 
 [project.scripts]

--- a/src/gis_mcp/data/land_cover.py
+++ b/src/gis_mcp/data/land_cover.py
@@ -1,0 +1,337 @@
+import json
+import logging
+from pathlib import Path
+from typing import Optional, Dict, Any, List, Union
+
+from ..mcp import gis_mcp
+
+from pystac_client import Client
+import planetary_computer as pc
+
+import numpy as np
+import rasterio
+from rasterio.enums import Resampling, ColorInterp
+from rasterio.mask import mask as rio_mask
+from shapely.geometry import shape as shapely_shape, box as shapely_box, mapping as shapely_mapping
+from shapely.ops import transform as shapely_transform
+from pyproj import Transformer
+
+logger = logging.getLogger(__name__)
+
+MPC_STAC_URL = "https://planetarycomputer.microsoft.com/api/stac/v1"
+DEFAULT_PATH = Path(__file__).resolve().parent / "land_products"
+
+
+def _ensure_dir(p: Optional[str]) -> Path:
+    out_dir = Path(p) if p else DEFAULT_PATH
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return out_dir
+
+def _parse_bbox(bbox_str: Optional[str]) -> Optional[List[float]]:
+    if not bbox_str:
+        return None
+    parts = [p.strip() for p in bbox_str.split(",")]
+    if len(parts) != 4:
+        raise ValueError("bbox must be 'minx,miny,maxx,maxy'")
+    return [float(v) for v in parts]
+
+def _project_geometry_to(to_crs: str, geom, from_crs: str = "EPSG:4326"):
+    transformer = Transformer.from_crs(from_crs, to_crs, always_xy=True)
+    return shapely_transform(lambda x, y: transformer.transform(x, y), geom)
+
+def _project_geojson_to(to_crs: str, geom_geojson: dict, from_crs: str = "EPSG:4326"):
+    geom = shapely_shape(geom_geojson)
+    return shapely_mapping(_project_geometry_to(to_crs, geom, from_crs=from_crs))
+
+def _bounds_intersect(a, b):
+    ax1, ay1, ax2, ay2 = a
+    bx1, by1, bx2, by2 = b
+    return not (ax2 <= bx1 or bx2 <= ax1 or ay2 <= by1 or by2 <= ay1)
+
+def _stac_search_one(collection: str,
+                     intersects: Optional[dict],
+                     bbox: Optional[List[float]],
+                     datetime: Optional[str],
+                     query: Optional[dict] = None):
+    """Return first matching item; prefer least-cloudy if eo:cloud_cover exists."""
+    catalog = Client.open(MPC_STAC_URL)
+
+    def _run(dt, q):
+        kwargs = {"collections": [collection]}
+        if dt:
+            kwargs["datetime"] = dt
+        if intersects is not None:
+            kwargs["intersects"] = intersects
+        elif bbox:
+            kwargs["bbox"] = bbox
+        if q:
+            kwargs["query"] = q
+        return list(catalog.search(**kwargs).items())
+
+    items = _run(datetime, query)
+    if not items and datetime:
+        items = _run(None, query)
+
+    if not items:
+        raise RuntimeError("No items found for collection/search constraints.")
+
+    items.sort(key=lambda it: it.properties.get("eo:cloud_cover", 0 if "eo:cloud_cover" in it.properties else 0))
+    return items[0]
+
+def _read_clip_reproject(href: str,
+                         geometry_geojson: Optional[dict],
+                         bbox_vals: Optional[List[float]],
+                         out_crs: Optional[str],
+                         resampling: Resampling = Resampling.nearest):
+    """Open a (signed) COG, optionally clip to ROI, and optionally reproject to out_crs."""
+    signed = pc.sign(href)
+    with rasterio.Env():
+        with rasterio.open(signed) as src:
+            src_crs = src.crs
+            if src_crs is None:
+                raise RuntimeError("Source asset has no CRS; cannot process safely.")
+
+            roi_geom_src = None
+            if geometry_geojson:
+                roi_geom_src = _project_geojson_to(str(src_crs), geometry_geojson)
+            elif bbox_vals:
+                roi_geom_src = _project_geojson_to(str(src_crs), shapely_mapping(shapely_box(*bbox_vals)))
+
+            if roi_geom_src:
+                roi_bounds = shapely_shape(roi_geom_src).bounds
+                if not _bounds_intersect(roi_bounds, src.bounds):
+                    raise RuntimeError(
+                        f"ROI does not intersect asset. ROI(bounds)={roi_bounds}, asset(bounds)={src.bounds}"
+                    )
+                data, transform = rio_mask(src, [roi_geom_src], crop=True, nodata=src.nodata)
+                profile = src.profile.copy()
+                count = data.shape[0]
+            else:
+                data = src.read()
+                transform = src.transform
+                profile = src.profile.copy()
+                count = profile.get("count", data.shape[0])
+
+            if out_crs and str(out_crs) != str(src_crs):
+                from rasterio.vrt import WarpedVRT
+                from rasterio.warp import calculate_default_transform
+                transform_out, width_out, height_out = calculate_default_transform(
+                    src_crs, out_crs, src.width, src.height, *src.bounds
+                )
+                with rasterio.open(signed) as rs:
+                    with WarpedVRT(rs, crs=out_crs, transform=transform_out,
+                                   width=width_out, height=height_out,
+                                   resampling=resampling) as vrt:
+                        if roi_geom_src:
+                            roi_geom_out = _project_geojson_to(
+                                out_crs, shapely_mapping(shapely_shape(roi_geom_src)), from_crs=str(src_crs)
+                            )
+                            data, transform = rio_mask(vrt, [roi_geom_out], crop=True, nodata=vrt.nodata)
+                        else:
+                            data = vrt.read()
+                            transform = vrt.transform
+                profile.update({"crs": out_crs, "transform": transform,
+                                "width": data.shape[-1], "height": data.shape[-2], "count": data.shape[0]})
+            else:
+                profile.update({"transform": transform,
+                                "width": data.shape[-1], "height": data.shape[-2], "count": count})
+
+            if data.size == 0:
+                raise RuntimeError("Read produced empty data. Check ROI and CRS.")
+
+            return data, profile
+
+def _write_gtiff(out_path: Path, data: np.ndarray, profile: Dict[str, Any],
+                 colorinterp: Optional[List[ColorInterp]] = None):
+    prof = profile.copy()
+    prof.update(driver="GTiff", compress="deflate", tiled=True, bigtiff="IF_SAFER")
+    with rasterio.open(out_path, "w", **prof) as dst:
+        if data.ndim == 2:
+            dst.write(data, 1)
+        else:
+            for i in range(data.shape[0]):
+                dst.write(data[i], i + 1)
+        if colorinterp:
+            dst.colorinterp = tuple(colorinterp)
+
+@gis_mcp.resource("gis://operations/land_products")
+def get_land_products() -> dict:
+    """List available land products operations."""
+    return {"operations": ["download_worldcover", "compute_s2_ndvi"]}
+
+@gis_mcp.tool()
+def download_worldcover(
+    year: int = 2021,
+    collection: Optional[str] = None,
+    asset_key: str = "map",
+    bbox: Optional[str] = None,
+    geometry_geojson: Optional[str] = None,
+    out_crs: Optional[str] = "EPSG:4326",
+    filename: Optional[str] = None,
+    path: Optional[str] = None
+) -> Dict[str, Any]:
+    """
+    Download ESA WorldCover (10 m) for the given AOI and year from Microsoft Planetary Computer.
+    - Crops to bbox/geometry (WGS84), optional reprojection.
+    - Writes a single-band categorical GeoTIFF (land cover classes).
+    Notes:
+      * On MPC, the collection is commonly 'esa-worldcover' with yearly items; the default here
+        auto-selects by year. If your deployment uses different IDs, pass `collection` explicitly.
+      * `asset_key` is typically 'map'.
+
+    Args:
+        year: WorldCover year (e.g., 2020, 2021, 2023).
+        collection: STAC collection (default resolves to 'esa-worldcover').
+        asset_key: Asset key to read ('map' usually).
+        bbox: "minx,miny,maxx,maxy" WGS84.
+        geometry_geojson: GeoJSON geometry string (WGS84).
+        out_crs: Output CRS (default EPSG:4326).
+        filename: Output filename (e.g., "worldcover_iran_2021.tif").
+        path: Output directory.
+
+    Returns:
+        dict with status, file_path, item_id, collection, properties.
+    """
+    try:
+        out_dir = _ensure_dir(path)
+        bbox_vals = _parse_bbox(bbox) if bbox else None
+        geom_obj = json.loads(geometry_geojson) if geometry_geojson else None
+
+        coll = collection or "esa-worldcover"
+        dt = f"{year}-01-01/{year}-12-31"
+
+        item = _stac_search_one(
+            collection=coll,
+            intersects=geom_obj,
+            bbox=bbox_vals,
+            datetime=dt,
+            query=None
+        )
+
+        if asset_key not in item.assets:
+            raise RuntimeError(f"Asset '{asset_key}' not found in item '{item.id}'. Available: {list(item.assets.keys())}")
+
+        data, profile = _read_clip_reproject(
+            href=item.assets[asset_key].href,
+            geometry_geojson=geom_obj,
+            bbox_vals=bbox_vals,
+            out_crs=out_crs,
+            resampling=Resampling.nearest
+        )
+
+        if not filename:
+            filename = f"worldcover_{year}_{item.id}.tif"
+        out_path = out_dir / filename
+
+        profile.update(count=1, dtype=data.dtype.name if hasattr(data, "dtype") else profile.get("dtype", "uint16"))
+        if data.ndim == 3:
+            data = data[0]
+
+        _write_gtiff(out_path, data, profile)
+
+        logger.info("Saved WorldCover to %s", out_path)
+        return {
+            "status": "success",
+            "file_path": str(out_path),
+            "item_id": item.id,
+            "collection": coll,
+            "year": year,
+            "asset": asset_key,
+            "properties": item.properties,
+        }
+    except Exception as e:
+        logger.exception("Failed to download WorldCover")
+        return {"status": "error", "message": str(e)}
+
+@gis_mcp.tool()
+def compute_s2_ndvi(
+    datetime: str = "2024-07-01/2024-07-15",
+    cloud_cover_lt: Optional[int] = 20,
+    bbox: Optional[str] = None,
+    geometry_geojson: Optional[str] = None,
+    out_crs: Optional[str] = "EPSG:4326",
+    filename: Optional[str] = None,
+    path: Optional[str] = None
+) -> Dict[str, Any]:
+    """
+    Compute NDVI from Sentinel-2 L2A (B08=NIR, B04=Red) for an AOI/time window via MPC.
+    - Picks a low-cloud item intersecting the AOI.
+    - Clips to AOI and writes single-band NDVI GeoTIFF scaled to float32 (-1..1).
+
+    Args:
+        datetime: STAC datetime/interval (e.g., "2024-07-01/2024-07-15").
+        cloud_cover_lt: Only consider items with eo:cloud_cover < value. Use None to disable.
+        bbox: "minx,miny,maxx,maxy" (WGS84).
+        geometry_geojson: GeoJSON geometry (WGS84).
+        out_crs: Output CRS for NDVI raster.
+        filename: Output filename (default auto-generated).
+        path: Output directory.
+
+    Returns:
+        dict with status, file_path, item_id, collection, properties.
+    """
+    try:
+        out_dir = _ensure_dir(path)
+        bbox_vals = _parse_bbox(bbox) if bbox else None
+        geom_obj = json.loads(geometry_geojson) if geometry_geojson else None
+
+        collection = "sentinel-2-l2a"
+        query = {"eo:cloud_cover": {"lt": cloud_cover_lt}} if cloud_cover_lt is not None else None
+
+        item = _stac_search_one(
+            collection=collection,
+            intersects=geom_obj,
+            bbox=bbox_vals,
+            datetime=datetime,
+            query=query
+        )
+
+        need_assets = {"B08": "NIR", "B04": "RED"}
+        hrefs = {}
+        for k in need_assets.keys():
+            if k not in item.assets:
+                raise RuntimeError(f"Sentinel-2 asset '{k}' not available in item '{item.id}'.")
+            hrefs[k] = item.assets[k].href
+
+        nir, nir_profile = _read_clip_reproject(
+            href=hrefs["B08"], geometry_geojson=geom_obj, bbox_vals=bbox_vals, out_crs=out_crs,
+            resampling=Resampling.bilinear
+        )
+        red, red_profile = _read_clip_reproject(
+            href=hrefs["B04"], geometry_geojson=geom_obj, bbox_vals=bbox_vals, out_crs=out_crs,
+            resampling=Resampling.bilinear
+        )
+
+        nir_arr = nir[0] if nir.ndim == 3 else nir
+        red_arr = red[0] if red.ndim == 3 else red
+
+        if nir_arr.shape != red_arr.shape:
+            raise RuntimeError(f"Band shape mismatch after processing: NIR{nir_arr.shape} vs RED{red_arr.shape}")
+
+        nir_arr = nir_arr.astype("float32")
+        red_arr = red_arr.astype("float32")
+        denom = (nir_arr + red_arr)
+        ndvi = (nir_arr - red_arr) / np.where(denom == 0, np.nan, denom)
+        ndvi = np.nan_to_num(ndvi, nan=0.0).astype("float32")
+
+        out_profile = nir_profile.copy()
+        out_profile.update(count=1, dtype="float32", nodata=np.float32(0.0))
+
+        if not filename:
+            filename = f"s2_ndvi_{item.id}.tif"
+        out_path = out_dir / filename
+
+        _write_gtiff(out_path, ndvi, out_profile)
+
+        logger.info("Saved NDVI to %s", out_path)
+        return {
+            "status": "success",
+            "file_path": str(out_path),
+            "item_id": item.id,
+            "collection": collection,
+            "assets": ["B08", "B04"],
+            "properties": item.properties,
+        }
+    except Exception as e:
+        logger.exception("Failed to compute NDVI")
+        return {"status": "error", "message": str(e)}

--- a/src/gis_mcp/data/satellite_imagery.py
+++ b/src/gis_mcp/data/satellite_imagery.py
@@ -1,0 +1,313 @@
+import json
+import logging
+from pathlib import Path
+from typing import Optional, Dict, Any, List, Union
+
+from ..mcp import gis_mcp
+
+from pystac_client import Client
+import planetary_computer as pc
+
+import rasterio
+from rasterio.transform import Affine
+from rasterio.windows import from_bounds as window_from_bounds
+from rasterio.mask import mask as rio_mask
+from shapely.geometry import box as shapely_box, shape as shapely_shape, mapping as shapely_mapping
+from pyproj import Transformer
+from shapely.ops import transform as shapely_transform
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PATH = Path(__file__).resolve().parent / "satellite_imagery"
+MPC_STAC_URL = "https://planetarycomputer.microsoft.com/api/stac/v1"
+
+
+def _parse_bbox(bbox_str: Optional[str]) -> Optional[List[float]]:
+    """
+    Parse "minx,miny,maxx,maxy" -> [minx, miny, maxx, maxy]
+    """
+    if not bbox_str:
+        return None
+    parts = [p.strip() for p in bbox_str.split(",")]
+    if len(parts) != 4:
+        raise ValueError("bbox must be 'minx,miny,maxx,maxy'")
+    return [float(v) for v in parts]
+
+def _ensure_dir(p: Optional[str]) -> Path:
+    out_dir = Path(p) if p else DEFAULT_PATH
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return out_dir
+
+def _pick_item(collection: str,
+               bbox: Optional[List[float]],
+               datetime: str,
+               cloud_cover: Optional[int],
+               intersects: Optional[dict] = None):
+    catalog = Client.open(MPC_STAC_URL)
+
+    def _search(dt, cc):
+        kwargs = {"collections": [collection], "datetime": dt}
+        if intersects is not None:
+            kwargs["intersects"] = intersects
+        elif bbox:
+            kwargs["bbox"] = bbox
+        if cc is not None:
+            kwargs["query"] = {"eo:cloud_cover": {"lt": cc}}
+        return list(catalog.search(**kwargs).items())
+
+    items = _search(datetime, cloud_cover)
+    if not items and cloud_cover is not None:
+        items = _search(datetime, None)
+    if not items:
+        try:
+            start, end = datetime.split("/")
+            items = _search(f"{start}/{end}", None)
+            if not items:
+                items = _search("2018-01-01/2100-01-01", None)
+        except Exception:
+            items = _search("2018-01-01/2100-01-01", None)
+
+    if not items:
+        raise RuntimeError("No items found. Try widening date range or removing cloud filter.")
+
+    items.sort(key=lambda it: it.properties.get("eo:cloud_cover", 1000))
+    return items[0]
+
+
+
+def _read_and_optionally_clip(
+    href: str,
+    bbox: Optional[List[float]],
+    geometry_geojson: Optional[dict],
+    out_crs: Optional[str]
+):
+    """
+    Read a single-band COG from a (signed) href, with robust bbox/geometry handling:
+    - If bbox/geometry are assumed WGS84 (typical), they are reprojected to the asset CRS for cropping.
+    - Protects against empty windows (0x0) and raises a helpful error instead of cryptic rasterio errors.
+    - Optional reprojection to out_crs after cropping.
+    """
+    signed = pc.sign(href)
+    with rasterio.Env():
+        with rasterio.open(signed) as src:
+            src_crs = src.crs
+            if src_crs is None:
+                raise RuntimeError("Source asset has no CRS; cannot crop safely.")
+
+            roi_geom_src = None
+            if geometry_geojson:
+                roi_geom_src = _project_geojson_to(src_crs, geometry_geojson)
+            elif bbox:
+                bbox_geom_wgs84 = shapely_box(*bbox)
+                roi_geom_src = _project_geometry_to(src_crs, bbox_geom_wgs84, from_crs="EPSG:4326")
+
+            if roi_geom_src:
+                roi_bounds = shapely_shape(roi_geom_src).bounds
+                if not _bounds_intersect(roi_bounds, src.bounds):
+                    raise RuntimeError(
+                        f"ROI does not intersect asset. ROI(bounds)={roi_bounds}, asset(bounds)={src.bounds}"
+                    )
+                data, transform = rio_mask(src, [roi_geom_src], crop=True, nodata=src.nodata)
+                if data.ndim == 3:
+                    data = data[0]
+                if data.size == 0 or data.shape[0] == 0 or data.shape[1] == 0:
+                    raise RuntimeError("Crop produced an empty window (0x0). Check ROI and CRS.")
+                profile = src.profile.copy()
+                profile.update({
+                    "height": data.shape[0],
+                    "width": data.shape[1],
+                    "transform": transform,
+                    "count": 1,
+                    "crs": src_crs
+                })
+            else:
+                data = src.read(1)
+                profile = src.profile.copy()
+                profile.update({"count": 1})
+                if data.size == 0:
+                    raise RuntimeError("Read returned empty data unexpectedly.")
+
+            if out_crs and str(out_crs) != str(profile["crs"]):
+                from rasterio.vrt import WarpedVRT
+                from rasterio.warp import calculate_default_transform
+
+                transform_out, width_out, height_out = calculate_default_transform(
+                    src_crs, out_crs, src.width, src.height, *src.bounds
+                )
+                with WarpedVRT(src, crs=out_crs, transform=transform_out,
+                               width=width_out, height=height_out) as vrt:
+                    if roi_geom_src:
+                        roi_geom_out = _project_geojson_to(
+                            out_crs,
+                            shapely_mapping(shapely_shape(roi_geom_src)),
+                            from_crs=str(src_crs)
+                        )
+
+                        data, transform2 = rio_mask(vrt, [roi_geom_out], crop=True, nodata=vrt.nodata)
+                        data = data[0] if data.ndim == 3 else data
+                        transform = transform2
+                    else:
+                        data = vrt.read(1)
+                        transform = vrt.transform
+
+                if data.size == 0 or data.shape[0] == 0 or data.shape[1] == 0:
+                    raise RuntimeError("Reprojected read produced empty data (0x0). Check ROI and CRS.")
+                profile.update({
+                    "crs": out_crs,
+                    "transform": transform,
+                    "width": data.shape[1],
+                    "height": data.shape[0]
+                })
+
+            return data, profile
+
+
+def _project_geojson_to(to_crs, geom_geojson, from_crs="EPSG:4326"):
+    geom = shapely_shape(geom_geojson)
+    return shapely_mapping(_project_geometry_to(to_crs, geom, from_crs=from_crs))
+
+
+def _project_geometry_to(to_crs, geom, from_crs="EPSG:4326"):
+    """Project a Shapely geometry from `from_crs` to `to_crs`."""
+    transformer = Transformer.from_crs(from_crs, to_crs, always_xy=True)
+    return shapely_transform(lambda x, y: transformer.transform(x, y), geom)
+
+
+def _bounds_intersect(a, b):
+    ax1, ay1, ax2, ay2 = a
+    bx1, by1, bx2, by2 = b
+    return not (ax2 <= bx1 or bx2 <= ax1 or ay2 <= by1 or by2 <= ay1)
+
+
+def _write_multiband_geotiff(out_path: Path, bands: List[Any], profiles: List[Dict[str, Any]], dtype: Optional[str] = None):
+    """
+    Write stacked bands into a single GeoTIFF using the first profile as a template.
+    Assumes bands are aligned and same shape.
+    """
+    if not bands:
+        raise RuntimeError("No bands to write.")
+
+    base_profile = profiles[0].copy()
+    base_profile.update(
+        driver="GTiff",
+        count=len(bands),
+        compress="deflate",
+        tiled=True,
+        bigtiff="IF_SAFER"
+    )
+    if dtype:
+        base_profile["dtype"] = dtype
+
+    h0, w0 = bands[0].shape
+    for i, b in enumerate(bands):
+        if b.shape != (h0, w0):
+            raise RuntimeError(f"Band shape mismatch at index {i}: {b.shape} vs {(h0, w0)}")
+
+    with rasterio.open(out_path, "w", **base_profile) as dst:
+        for i, b in enumerate(bands, start=1):
+            dst.write(b, i)
+
+@gis_mcp.resource("gis://operations/satellite_imagery")
+def get_satellite_operations() -> dict:
+    """List available satellite imagery operations."""
+    return {"operations": ["download_satellite_imagery"]}
+
+@gis_mcp.tool()
+def download_satellite_imagery(
+    collection: str = "sentinel-2-l2a",
+    assets: Union[List[str], str] = ("B04", "B03", "B02"),
+    datetime: str = "2024-01-01/2024-12-31",
+    cloud_cover_lt: Optional[int] = 20,
+    bbox: Optional[str] = None, 
+    geometry_geojson: Optional[str] = None,
+    out_crs: Optional[str] = None,
+    filename: Optional[str] = None,
+    path: Optional[str] = None
+) -> Dict[str, Any]:
+    """
+    Download analysis-ready satellite imagery from Microsoft Planetary Computer (STAC + SAS).
+    - Picks the least-cloudy item matching your query (by default Sentinel-2 L2A).
+    - Downloads specified asset bands and writes a multi-band GeoTIFF.
+    - Optional bbox/geometry crop and CRS reprojection.
+
+    Args:
+        collection: STAC collection id (e.g., "sentinel-2-l2a", "landsat-8-c2-l2")
+        assets: list of asset keys to download (e.g., ["B04","B03","B02"])
+        datetime: STAC datetime/interval (e.g., "2025-08-01/2025-08-31" or "2025-08-05")
+        cloud_cover_lt: only items with eo:cloud_cover < this value. Use None to disable.
+        bbox: "minx,miny,maxx,maxy" (in degrees if using search with WGS84). Used for cropping window.
+        geometry_geojson: a GeoJSON geometry (string). If provided, precise clipping is applied.
+        out_crs: target CRS for output (e.g., "EPSG:4326"). If None, keep source asset CRS.
+        filename: output file name (without path). If None, an automatic name is generated.
+        path: output folder. Defaults to ./data/satellite_imagery
+
+    Returns:
+        {"status": "success", "file_path": "...", "item_id": "...", "collection": "...", "assets": [...], "properties": {...}}
+        or {"status": "error", "message": "..."}
+    """
+    try:
+        if isinstance(assets, str):
+            assets = [a.strip() for a in assets.split(",") if a.strip()]
+
+        out_dir = _ensure_dir(path)
+        bbox_vals = _parse_bbox(bbox) if bbox else None
+        geom_obj = json.loads(geometry_geojson) if geometry_geojson else None
+
+        item = _pick_item(
+            collection=collection,
+            bbox=bbox_vals,
+            datetime=datetime,
+            cloud_cover=cloud_cover_lt,
+            intersects=geom_obj 
+        )
+        if geom_obj and not bbox_vals:
+            minx, miny, maxx, maxy = shapely_shape(geom_obj).bounds
+            bbox_vals = [minx, miny, maxx, maxy]
+
+        bands = []
+        profiles = []
+        missing_assets = []
+        for asset_key in assets:
+            if asset_key not in item.assets:
+                missing_assets.append(asset_key)
+                continue
+
+            href = item.assets[asset_key].href
+            data, profile = _read_and_optionally_clip(
+                href=href,
+                bbox=bbox_vals,
+                geometry_geojson=geom_obj,
+                out_crs=out_crs
+            )
+            bands.append(data)
+            profiles.append(profile)
+
+        if missing_assets:
+            logger.warning("Missing assets in item %s: %s", item.id, ", ".join(missing_assets))
+            if not bands:
+                raise RuntimeError(f"Requested assets not available in the chosen item: {missing_assets}")
+
+        if not filename:
+            safe_assets = "-".join([a.lower() for a in assets if a not in missing_assets]) or "bands"
+            filename = f"{collection}_{item.id}_{safe_assets}.tif"
+        out_path = out_dir / filename
+
+        dtype = profiles[0].get("dtype")
+
+        _write_multiband_geotiff(out_path=out_path, bands=bands, profiles=profiles, dtype=dtype)
+
+        logger.info("Saved satellite imagery (%s) to %s", assets, out_path)
+
+        return {
+            "status": "success",
+            "file_path": str(out_path),
+            "item_id": item.id,
+            "collection": collection,
+            "assets": [a for a in assets if a not in missing_assets],
+            "missing_assets": missing_assets,
+            "properties": item.properties,
+        }
+
+    except Exception as e:
+        logger.exception("Failed to download satellite imagery")
+        return {"status": "error", "message": str(e)}

--- a/src/gis_mcp/main.py
+++ b/src/gis_mcp/main.py
@@ -36,6 +36,12 @@ except ImportError as e:
     import logging
     logging.warning(f"movement module could not be imported: {e}. Install with 'pip install gis-mcp[movement]' if you need this feature.")
 
+try:
+    from .data import satellite_imagery
+except ImportError as e:
+    satellite_imagery = None
+    import logging
+    logging.warning(f"satellite_imagery module could not be imported: {e}. Install with 'pip install gis-mcp[satellite_imagery]' if you need this feature.")
 
 
 import warnings

--- a/src/gis_mcp/main.py
+++ b/src/gis_mcp/main.py
@@ -43,6 +43,13 @@ except ImportError as e:
     import logging
     logging.warning(f"satellite_imagery module could not be imported: {e}. Install with 'pip install gis-mcp[satellite_imagery]' if you need this feature.")
 
+try:
+    from .data import land_cover
+except ImportError as e:
+    land_cover = None
+    import logging
+    logging.warning(f"land_cover module could not be imported: {e}. Install with 'pip install gis-mcp[land_cover]' if you need this feature.")
+
 
 import warnings
 warnings.filterwarnings('ignore')  # Suppress warnings for cleaner output


### PR DESCRIPTION
This adds a Satellite Imagery tool for downloading Sentinel-2 and other collections from the Microsoft Planetary Computer, with options for AOI clipping, cloud cover filtering, reprojection, and multi-band GeoTIFF export. It also adds Land Cover tools, including WorldCover land cover map downloads and NDVI computation from Sentinel-2 L2A. In addition, documentation has been expanded to cover the new tools.