### PR TITLE
Gcloud storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 | Category                     | Badges                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **Package**                  | [![PyPI version](https://img.shields.io/pypi/v/gis-mcp.svg)](https://pypi.org/project/gis-mcp/) [![PyPI downloads](https://static.pepy.tech/personalized-badge/gis-mcp?period=total&units=international_system&left_color=grey&right_color=blue&left_text=PyPI%20downloads)](https://pepy.tech/project/gis-mcp) [![Tests](https://github.com/mahdin75/gis-mcp/actions/workflows/test.yml/badge.svg)](https://github.com/mahdin75/gis-mcp/actions/workflows/test.yml)                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| **Installation & Transport** | [![Docker Installation](https://img.shields.io/badge/Docker-Installation-2496ED?logo=docker&logoColor=white)](https://gis-mcp.com/install/docker/) [![Transport](https://img.shields.io/badge/Transport-HTTP%20%7C%20stdio-blue)](https://github.com/mahdin75/gis-mcp) [![Storage](https://img.shields.io/badge/Storage-Supported-4CAF50?logo=files&logoColor=white)](https://gis-mcp.com/storage-configuration/)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| **Installation & Transport** | [![Docker Installation](https://img.shields.io/badge/Docker-Installation-2496ED?logo=docker&logoColor=white)](https://gis-mcp.com/install/docker/) [![Transport](https://img.shields.io/badge/Transport-HTTP%20%7C%20stdio-blue)](https://github.com/mahdin75/gis-mcp)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| **Storage**                  | [![Local Filesystem](https://img.shields.io/badge/Local-Filesystem-4CAF50?logo=files&logoColor=white)](https://gis-mcp.com/storage-configuration/) [![GCP Cloud Storage](https://img.shields.io/badge/GCP-Cloud%20Storage-4285F4?logo=googlecloud&logoColor=white)](https://gis-mcp.com/storage-configuration/)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | **Data Sources**             | [![Climate](https://img.shields.io/badge/Climate-Data-B91C1C?logo=weather&logoColor=white)](https://gis-mcp.com/data-gathering/climate/) [![Biodiversity](https://img.shields.io/badge/Biodiversity-Data-4CAF50?logo=leaf&logoColor=white)](https://gis-mcp.com/data-gathering/ecology/) [![LandCover](https://img.shields.io/badge/LandCover-Data-5D4037?logo=map&logoColor=white)](https://gis-mcp.com/data-gathering/land_cover/) [![Movement](https://img.shields.io/badge/Movement-Data-FF6B35?logo=person-walking&logoColor=white)](https://gis-mcp.com/data-gathering/movement/) [![Satellite](https://img.shields.io/badge/Satellite-Imagery-6C5CE7?logo=satellite&logoColor=white)](https://gis-mcp.com/data-gathering/satellite_imagery/) [![Administrative](https://img.shields.io/badge/Administrative-Boundaries-7289DA?logo=map&logoColor=white)](https://gis-mcp.com/data-gathering/administrative_boundaries/) |
 | **Agentic AI**               | [![LangChain Agent Example](<https://img.shields.io/badge/LangChain-Agent%20Example%20(Python)-3776AB?logo=langchain&logoColor=white>)](https://gis-mcp.com/gis-ai-agent/langchain) [![OpenAI Agent Example](<https://img.shields.io/badge/OpenAI-Agent%20Example%20(Node.js)-111827?logo=openai&logoColor=white>)](https://gis-mcp.com/gis-ai-agent/openai-nodejs)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | **Community**                | [![Discord](https://img.shields.io/badge/Discord-Community-7289DA?logo=discord&logoColor=white)](https://discord.gg/SeVmVhVbk) [![YouTube](https://img.shields.io/badge/YouTube-Tutorials-B91C1C?logo=youtube&logoColor=white)](https://www.youtube.com/@gis-mcp) [![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/mahdin75/gis-mcp)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
@@ -27,7 +28,7 @@ A Model Context Protocol (MCP) server implementation that connects Large Languag
 
 🌐 **Website:** [gis-mcp.com](https://gis-mcp.com)
 
-> Current version is 0.14.0 (Beta):
+> Current version is 0.15.0 (Beta):
 >
 > We welcome contributions and developers to join us in building this project.
 
@@ -40,6 +41,7 @@ A Model Context Protocol (MCP) server implementation that connects Large Languag
 ## 📋 Table of Contents
 
 - [Features](#-features)
+- [Storage](#-storage)
 - [Prerequisites](#-prerequisites)
 - [Vibe Coding](#vibe-coding)
 - [Installation](#-installation)
@@ -82,9 +84,29 @@ GIS MCP Server empowers AI assistants with advanced geospatial intelligence. Key
 - 🔹 **Spatial Statistics & Modeling** – Leverage PySAL for spatial autocorrelation, clustering, and neighborhood analysis.
 - 🔹 **Easy Integration** – Connect seamlessly with MCP-compatible clients like Claude Desktop or Cursor IDE.
 - 🔹 **HTTP/SSE Transport** – Run as HTTP service with RESTful storage endpoints for file upload/download operations.
+- 🔹 **Flexible Storage** – Local filesystem by default, or Google Cloud Storage when you want files in a GCS bucket.
 - 🔹 **Flexible & Extensible** – Supports Python-based GIS libraries and is ready for custom tools or workflow extensions.
 
 > 🌟 **Tip:** With GIS MCP Server, your AI can now “think spatially,” unlocking new capabilities for environmental analysis, mapping, and location intelligence.
+
+---
+
+## 💾 Storage
+
+GIS MCP Server supports two storage backends for file upload, download, and tool outputs:
+
+| Backend | When to use | Configure with |
+| ------- | ----------- | -------------- |
+| **Local filesystem** | Default; files on disk (including Docker volumes) | `--storage-path` or `GIS_MCP_STORAGE_PATH` |
+| **Google Cloud Storage (GCP)** | When you want files in a GCS bucket | `--storage-config` / `GIS_MCP_STORAGE_CONFIG` or `GIS_MCP_STORAGE_PROVIDER=gcp` |
+
+Install GCP support with:
+
+```bash
+pip install gis-mcp[gcp]
+```
+
+Full setup (paths, IAM, Docker, credentials): [Storage Configuration](https://gis-mcp.com/storage-configuration/).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@
 
 A Model Context Protocol (MCP) server implementation that connects Large Language Models (LLMs) to GIS operations using GIS libraries, enabling AI assistants to perform geospatial operations and transformations.
 
+How it fits next to the LLM and other tools, plus internal components: **[Architecture](https://gis-mcp.com/architecture/)**.
+
 🌐 **Website:** [gis-mcp.com](https://gis-mcp.com)
 
 > Current version is 0.15.0 (Beta):

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,137 @@
+## Architecture
+
+This page explains **where GIS MCP Server sits in agentic AI apps** and **how the server is structured inside**. Diagrams live here (not in the GitHub README) so the docs stay the place for conceptual overview.
+
+---
+
+## Role in agentic AI applications
+
+An agentic app usually combines:
+
+- An **LLM** that reasons and plans
+- An **agent runtime / framework** (LangChain, OpenAI Agents SDK, Claude Desktop, Cursor, custom apps)
+- **Tools and MCP servers** that perform real actions (search, databases, APIs, GIS, …)
+
+**GIS MCP Server** is the geospatial tool layer. The LLM does not invent GIS math from scratch; it calls GIS MCP tools for buffers, projections, raster ops, spatial stats, data downloads, and related work. Other MCP servers or tools can sit beside it (web search, calendars, code runners, etc.).
+
+```mermaid
+flowchart LR
+  User([User / App UI])
+  Agent[Agent runtime<br/>LLM + planner]
+  MCPClient[MCP client]
+
+  GIS[GIS MCP Server]
+  Other[Other tools / MCP servers<br/>search, DB, APIs, …]
+
+  LLM[LLM provider]
+
+  User --> Agent
+  Agent <--> LLM
+  Agent --> MCPClient
+  MCPClient --> GIS
+  MCPClient --> Other
+```
+
+**What GIS MCP contributes**
+
+| Concern | Who handles it |
+| -------- | -------------- |
+| Natural language, planning, tool choice | LLM + agent runtime |
+| Buffers, CRS, rasters, GeoPandas, PySAL, maps | **GIS MCP Server** |
+| Files / layers persistence | GIS MCP **storage** (local or GCS) |
+| Non-GIS actions | Other tools / MCP servers |
+
+Typical flow: the user asks a spatial question → the agent selects GIS tools → GIS MCP runs library code → results (numbers, GeoJSON, files, maps) return to the agent → the LLM explains or continues the workflow.
+
+---
+
+## Server architecture and components
+
+At a high level the process is: **transport → MCP server → tools → GIS libraries**, with a shared **storage** backend for inputs/outputs.
+
+```mermaid
+flowchart TB
+  subgraph Clients
+    IDE[Claude / Cursor / IDE]
+    AgentApp[Custom agent app<br/>LangChain, OpenAI SDK, …]
+    HTTPClient[HTTP clients]
+  end
+
+  subgraph Transport
+    STDIO[stdio]
+    HTTP[HTTP / SSE]
+  end
+
+  subgraph GISMCP[GIS MCP Server]
+    Core[FastMCP core<br/>tool registry]
+    Analysis[Analysis tools<br/>Shapely · PyProj · GeoPandas<br/>Rasterio · PySAL]
+    Data[Data gathering<br/>climate · ecology · movement<br/>satellite · land cover · boundaries]
+    Viz[Visualization<br/>static + web maps]
+    StorageAPI[Storage HTTP endpoints<br/>upload · download · list]
+    Storage[Storage adapters]
+  end
+
+  subgraph Backends
+    LocalFS[(Local filesystem)]
+    GCS[(GCP Cloud Storage)]
+    Libs[GIS libraries]
+  end
+
+  IDE --> STDIO
+  AgentApp --> HTTP
+  HTTPClient --> HTTP
+  STDIO --> Core
+  HTTP --> Core
+  HTTP --> StorageAPI
+
+  Core --> Analysis
+  Core --> Data
+  Core --> Viz
+  Analysis --> Libs
+  Data --> Libs
+  Viz --> Libs
+
+  Analysis --> Storage
+  Data --> Storage
+  Viz --> Storage
+  StorageAPI --> Storage
+  Storage --> LocalFS
+  Storage --> GCS
+```
+
+### Component summary
+
+| Component | Role |
+| --------- | ---- |
+| **Transports** | `stdio` for desktop MCP clients; `HTTP` / `SSE` for remote agents and REST-style storage access |
+| **FastMCP core** | Registers tools and handles MCP protocol messages |
+| **Analysis tools** | Geometry, CRS, vector/raster processing, spatial statistics |
+| **Data gathering** | Download / fetch workflows (climate, ecology, OSM networks, imagery, boundaries, …) |
+| **Visualization** | Static maps and interactive web maps |
+| **Storage adapters** | Local disk (default) or GCS bucket when you configure GCP |
+| **Storage HTTP API** | `/storage/upload`, `/storage/download`, `/storage/list` (HTTP/SSE mode) |
+
+### Storage in the architecture
+
+```mermaid
+flowchart LR
+  Tools[GIS tools + storage API]
+  Adapter[Storage adapter]
+  Local[Local path / Docker volume]
+  GCP[GCS bucket]
+
+  Tools --> Adapter
+  Adapter -->|provider local| Local
+  Adapter -->|provider gcp| GCP
+```
+
+Configure storage as described in [Storage Configuration](storage-configuration.md).
+
+---
+
+## Where to go next
+
+- [Getting Started](getting-started.md) — install and run the server
+- [Build a GIS AI Agent](gis-ai-agent/README.md) — LangChain and OpenAI examples
+- [HTTP Transport](http-transport.md) — remote agent connectivity
+- [Server Endpoints](endpoints.md) — MCP and storage HTTP routes

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,6 +2,8 @@
 
 This guide helps you install and run the GIS MCP Server quickly using pip (with uv) and shows how to connect it to your IDE/client.
 
+For how GIS MCP fits beside the LLM and other tools, and how the server is structured, see **[Architecture](architecture.md)**.
+
 ### Prerequisites
 
 - Python 3.10+

--- a/docs/gis-ai-agent/README.md
+++ b/docs/gis-ai-agent/README.md
@@ -12,6 +12,8 @@ These tutorials will guide you through creating your own AI agents that can:
 - Perform spatial analysis
 - And much more!
 
+See **[Architecture](../architecture.md)** for diagrams of where GIS MCP sits in an agentic stack (LLM, agent runtime, other tools) and the server’s internal components.
+
 ## Available Agent Examples
 
 ### 1. Langchain (Python)

--- a/docs/index.md
+++ b/docs/index.md
@@ -228,6 +228,7 @@ html, body { height: 100%; width: 100%; margin: 0; padding: 0; }
     </div>
     <nav class="nav-links">
       <a href="getting-started/">Getting Started</a>
+      <a href="architecture/">Architecture</a>
       <a href="gis-ai-agent/">GIS AI Agent</a>
       <a href="install/">Installations</a>
       <a href="api/shapely/">API Reference</a>

--- a/docs/storage-configuration.md
+++ b/docs/storage-configuration.md
@@ -1,10 +1,17 @@
 ## Storage Configuration
 
-The GIS MCP Server uses a configurable storage directory for file operations (reading, writing, and downloading data). By default, files are stored in `~/.gis_mcp/data/`.
+The GIS MCP Server stores files used for reading, writing, and downloading geospatial data. Two storage backends are supported:
 
-### Specifying a Custom Storage Folder
+1. **Local filesystem** — default; files under `~/.gis_mcp/data/` (or a custom path)
+2. **Google Cloud Storage (GCP)** — use when you want files in a GCS bucket
 
-You can specify a custom storage folder using either:
+---
+
+## Local filesystem storage
+
+This is the default. Configure it with `--storage-path` or `GIS_MCP_STORAGE_PATH`.
+
+### Custom storage folder
 
 1. **Command-line argument:**
 
@@ -26,33 +33,31 @@ $env:GIS_MCP_STORAGE_PATH="C:\path\to\your\storage"
 gis-mcp
 ```
 
-### Default Storage Location
+### Default storage location
 
-If no storage path is specified, the server uses the default location:
+If no path is set, the server uses:
 
-- **Default path:** `~/.gis_mcp/data/`
+- **Default:** `~/.gis_mcp/data/`
   - Linux/Mac: `/home/username/.gis_mcp/data/`
   - Windows: `C:\Users\username\.gis_mcp\data\`
 
-The storage directory is automatically created if it doesn't exist.
+The directory is created automatically if it does not exist.
 
-### How Storage Works
+### How local storage works
 
-- **File writes:** When you save files using tools like `write_file_gpd`, `write_raster`, or `save_results`, relative paths are resolved relative to the storage directory. Absolute paths are used as-is.
-- **Data downloads:** Downloaded data (satellite imagery, climate data, movement networks, etc.) is saved to subdirectories within the storage folder:
-  - `movement_data/` - Street networks
-  - `land_products/` - Land cover data
-  - `satellite_imagery/` - Satellite imagery
-  - `ecology_data/` - Species occurrence data
-  - `climate_data/` - Climate datasets
-  - `administrative_boundaries/` - Administrative boundaries
-  - `outputs/` - General output files
+- **File writes:** Tools such as `write_file_gpd`, `write_raster`, or `save_results` resolve relative paths against the storage directory. Absolute paths are used as-is.
+- **Data downloads:** Downloaded data is saved under subdirectories of the storage folder:
+  - `movement_data/` — street networks
+  - `land_products/` — land cover
+  - `satellite_imagery/` — satellite imagery
+  - `ecology_data/` — species occurrences
+  - `climate_data/` — climate datasets
+  - `administrative_boundaries/` — administrative boundaries
+  - `outputs/` — general outputs
 
-### Example Configuration for MCP Clients
+### MCP client example (local)
 
-For Claude Desktop or Cursor IDE, you can specify the storage path in your configuration.
-
-**Claude Desktop / Cursor (JSON config):**
+**Claude Desktop / Cursor:**
 
 ```json
 {
@@ -65,7 +70,7 @@ For Claude Desktop or Cursor IDE, you can specify the storage path in your confi
 }
 ```
 
-On Windows, adjust the command path accordingly, for example:
+Windows:
 
 ```json
 {
@@ -78,29 +83,191 @@ On Windows, adjust the command path accordingly, for example:
 }
 ```
 
-### Environment Variable Configuration
-
-Instead of passing `--storage-path`, you can configure the environment variable in your shell profile:
+### Persist the local path in your shell
 
 ```bash
 export GIS_MCP_STORAGE_PATH=/custom/path/to/storage
 ```
 
-Or in PowerShell:
+PowerShell:
 
 ```powershell
 $env:GIS_MCP_STORAGE_PATH="C:\custom\path\to\storage"
 ```
 
-This ensures all future `gis-mcp` runs use the specified storage directory by default.
+---
 
-### Docker: Persistent Storage with Volumes
+## Google Cloud Storage (GCP)
 
-When running GIS MCP Server in Docker, data inside containers is ephemeral by default. To persist your storage data, you need to mount a Docker volume.
+Use this backend when you want the server to read and write files in a **Google Cloud Storage** bucket.
 
-#### Using Host Directory Mount
+### Install
 
-Mount a directory from your host machine to the container's storage path:
+```bash
+pip install gis-mcp[gcp]
+```
+
+(`gis-mcp[all]` also includes the GCP client.)
+
+### Configuration
+
+```json
+{
+  "provider": "gcp",
+  "bucket": "my-gis-bucket",
+  "prefix": "gis-data/",
+  "credentials": "/path/to/service-account.json"
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `provider` | yes | `"gcp"` |
+| `bucket` | yes | GCS bucket name |
+| `prefix` | no | Object prefix (e.g. `gis-data/`) |
+| `credentials` | no | Path to a service-account JSON key |
+| `project` | no | GCP project ID (often inferred from credentials) |
+| `local_cache` | no | Local cache for GIS tools (default: `~/.gis_mcp/gcp_cache/<bucket>/`) |
+
+**CLI:**
+
+```bash
+gis-mcp --storage-config '{"provider":"gcp","bucket":"my-gis-bucket","prefix":"gis-data/"}'
+```
+
+Or a JSON file:
+
+```bash
+gis-mcp --storage-config /path/to/storage.json
+```
+
+**Single env var:**
+
+```bash
+export GIS_MCP_STORAGE_CONFIG='{"provider":"gcp","bucket":"my-gis-bucket","prefix":"gis-data/"}'
+gis-mcp
+```
+
+**Separate env vars:**
+
+```bash
+export GIS_MCP_STORAGE_PROVIDER=gcp
+export GIS_MCP_GCS_BUCKET=my-gis-bucket
+export GIS_MCP_GCS_PREFIX=gis-data/
+export GIS_MCP_GCS_CREDENTIALS=/path/to/service-account.json   # if using a key file
+gis-mcp
+```
+
+### Credentials
+
+Resolved in this order:
+
+1. `credentials` in `storage_config` (or `GIS_MCP_GCS_CREDENTIALS`)
+2. `GOOGLE_APPLICATION_CREDENTIALS`
+3. [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials)
+
+The path must be readable by the **process that runs `gis-mcp`**:
+
+- **Linux host (no Docker):** path on the host
+- **Docker:** path **inside the container**, with the host key mounted there
+
+#### Linux — run on the host
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS=/home/ubuntu/secrets/gis-mcp-sa.json
+export GIS_MCP_STORAGE_PROVIDER=gcp
+export GIS_MCP_GCS_BUCKET=my-gis-bucket
+export GIS_MCP_GCS_PREFIX=gis-data/
+gis-mcp
+```
+
+Or:
+
+```bash
+gis-mcp --storage-config '{
+  "provider": "gcp",
+  "bucket": "my-gis-bucket",
+  "prefix": "gis-data/",
+  "credentials": "/home/ubuntu/secrets/gis-mcp-sa.json"
+}'
+```
+
+#### Linux — run in Docker
+
+Env vars use the **container** path; mount the host key into that path:
+
+```bash
+# Host:      /home/ubuntu/secrets/gis-mcp-sa.json
+# Container: /secrets/gis-mcp-sa.json
+docker run -p 9010:9010 \
+  -e GIS_MCP_STORAGE_PROVIDER=gcp \
+  -e GIS_MCP_GCS_BUCKET=my-gis-bucket \
+  -e GIS_MCP_GCS_PREFIX=gis-data/ \
+  -e GOOGLE_APPLICATION_CREDENTIALS=/secrets/gis-mcp-sa.json \
+  -v /home/ubuntu/secrets/gis-mcp-sa.json:/secrets/gis-mcp-sa.json:ro \
+  gis-mcp
+```
+
+### Bucket access (IAM)
+
+The server **reads, writes, and lists** objects in the bucket:
+
+| Operation | Used for |
+|-----------|----------|
+| Write / upload | `POST /storage/upload` |
+| Read / download | `GET /storage/download` |
+| List | `GET /storage/list` |
+
+Recommended role on the bucket: **`roles/storage.objectUser`** (Storage Object User).
+
+Minimum custom permissions:
+
+- `storage.objects.create`
+- `storage.objects.get`
+- `storage.objects.list`
+
+```bash
+gcloud storage buckets add-iam-policy-binding gs://my-gis-bucket \
+  --member="serviceAccount:gis-mcp@PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/storage.objectUser"
+```
+
+Do not use read-only roles such as `roles/storage.objectViewer` if you need uploads.
+
+### How GCP storage works
+
+- Storage HTTP endpoints read and write objects in the configured bucket (under the prefix, if set).
+- GIS tools that need real filesystem paths use a local cache; files written through the storage API are mirrored into that cache.
+- Local path settings (`--storage-path` / `GIS_MCP_STORAGE_PATH`) continue to use the local filesystem backend.
+
+### MCP client example (GCP on Linux host)
+
+```json
+{
+  "mcpServers": {
+    "gis-mcp": {
+      "command": "/home/YourUsername/.venv/bin/gis-mcp",
+      "args": [
+        "--storage-config",
+        "{\"provider\":\"gcp\",\"bucket\":\"my-gis-bucket\",\"prefix\":\"gis-data/\"}"
+      ],
+      "env": {
+        "GOOGLE_APPLICATION_CREDENTIALS": "/home/YourUsername/secrets/gis-mcp-sa.json"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Docker
+
+In Docker (`Dockerfile` or `Dockerfile.local`), container filesystem data is ephemeral unless you mount a volume. Use a volume for **local** storage, or configure **GCP** when you want a GCS bucket.
+
+### Local storage with volumes
+
+#### Host directory mount
 
 ```bash
 # Linux/Mac
@@ -114,23 +281,17 @@ docker run -p 9010:9010 \
   gis-mcp
 ```
 
-#### Using Named Docker Volumes
-
-Named volumes are managed by Docker and provide better portability:
+#### Named volume
 
 ```bash
-# Create a named volume
 docker volume create gis-mcp-storage
 
-# Run container with the named volume
 docker run -p 9010:9010 \
   -v gis-mcp-storage:/app/.gis_mcp/data \
   gis-mcp
 ```
 
-#### Custom Storage Path in Docker
-
-You can use a custom storage path inside the container by combining volume mounting with environment variables:
+#### Custom path inside the container
 
 ```bash
 docker run -p 9010:9010 \
@@ -139,18 +300,45 @@ docker run -p 9010:9010 \
   gis-mcp
 ```
 
-Or with a named volume:
+Default path in the image is `/app/.gis_mcp/data/` unless you set `GIS_MCP_STORAGE_PATH`.
+
+### GCP storage in Docker
+
+Images built with `gis-mcp[all]` include the GCP client. Point credentials at a path **inside the container** and mount the host key:
 
 ```bash
 docker run -p 9010:9010 \
-  -v gis-mcp-storage:/container/storage \
-  -e GIS_MCP_STORAGE_PATH=/container/storage \
+  -e GIS_MCP_STORAGE_PROVIDER=gcp \
+  -e GIS_MCP_GCS_BUCKET=my-gis-bucket \
+  -e GIS_MCP_GCS_PREFIX=gis-data/ \
+  -e GOOGLE_APPLICATION_CREDENTIALS=/secrets/gis-mcp-sa.json \
+  -v /home/ubuntu/secrets/gis-mcp-sa.json:/secrets/gis-mcp-sa.json:ro \
   gis-mcp
 ```
 
-#### Docker Compose Example
+Docker Compose (Linux, GCP):
 
-For easier management, use `docker-compose.yml`:
+```yaml
+services:
+  gis-mcp:
+    image: gis-mcp:latest
+    ports:
+      - "9010:9010"
+    environment:
+      - GIS_MCP_TRANSPORT=http
+      - GIS_MCP_HOST=0.0.0.0
+      - GIS_MCP_PORT=9010
+      - GIS_MCP_STORAGE_PROVIDER=gcp
+      - GIS_MCP_GCS_BUCKET=my-gis-bucket
+      - GIS_MCP_GCS_PREFIX=gis-data/
+      - GOOGLE_APPLICATION_CREDENTIALS=/secrets/gis-mcp-sa.json
+    volumes:
+      - /home/ubuntu/secrets/gis-mcp-sa.json:/secrets/gis-mcp-sa.json:ro
+```
+
+On GCE/GKE you can often omit the key file and use the attached service account (ADC).
+
+### Docker Compose (local volume)
 
 ```yaml
 version: "3.8"
@@ -161,77 +349,39 @@ services:
     ports:
       - "9010:9010"
     volumes:
-      # Option 1: Named volume (recommended)
       - gis-mcp-data:/app/.gis_mcp/data
-
-      # Option 2: Host directory mount
-      # - ./gis-data:/app/.gis_mcp/data
-
-      # Option 3: Custom path with environment variable
-      # - gis-mcp-data:/custom/storage
     environment:
       - GIS_MCP_TRANSPORT=http
       - GIS_MCP_HOST=0.0.0.0
       - GIS_MCP_PORT=9010
-      # Uncomment if using custom storage path
-      # - GIS_MCP_STORAGE_PATH=/custom/storage
 
 volumes:
   gis-mcp-data:
-    # Optional: Use a specific driver or external volume
-    # driver: local
-    # driver_opts:
-    #   type: none
-    #   o: bind
-    #   device: /host/path/to/storage
 ```
 
-#### Managing Docker Volumes
-
-**List all volumes:**
+### Managing volumes
 
 ```bash
 docker volume ls
-```
-
-**Inspect a volume:**
-
-```bash
 docker volume inspect gis-mcp-storage
-```
 
-**Backup a volume:**
-
-```bash
+# Backup
 docker run --rm \
   -v gis-mcp-storage:/data \
   -v $(pwd):/backup \
   alpine tar czf /backup/gis-mcp-backup.tar.gz -C /data .
-```
 
-**Restore a volume:**
-
-```bash
+# Restore
 docker run --rm \
   -v gis-mcp-storage:/data \
   -v $(pwd):/backup \
   alpine tar xzf /backup/gis-mcp-backup.tar.gz -C /data
-```
 
-**Remove a volume:**
-
-```bash
 docker volume rm gis-mcp-storage
 ```
 
-#### Best Practices
+### Docker tips
 
-- **Use named volumes** for production deployments as they're easier to manage and backup
-- **Use host directory mounts** for development when you need direct file access
-- **Set appropriate permissions** on host directories to ensure the container can write to them
-- **Regular backups** of volumes are recommended, especially for production data
-- **Document your volume strategy** in your deployment documentation
-
-#### Default Storage Path in Docker
-
-Inside Docker containers, the default storage path is `/app/.gis_mcp/data/`. When mounting volumes, ensure you mount to this path unless you're using a custom `GIS_MCP_STORAGE_PATH` environment variable.
+- Prefer named volumes in production; host mounts are convenient for development
+- Ensure the container user can write to mounted host directories
+- Back up volumes regularly for important data

--- a/docs/storage-configuration.md
+++ b/docs/storage-configuration.md
@@ -99,7 +99,19 @@ $env:GIS_MCP_STORAGE_PATH="C:\custom\path\to\storage"
 
 ## Google Cloud Storage (GCP)
 
-Use this backend when you want the server to read and write files in a **Google Cloud Storage** bucket.
+Use this backend when you want the server to read and write files in a **Google Cloud Storage** bucket instead of (or in addition to caching on) a local disk path.
+
+### Why use a GCS bucket?
+
+Local storage is fine for a single machine or a Docker volume on one host. A GCS bucket helps when geospatial files need to live in shared, durable cloud storage:
+
+- **Shared access** — several agents, servers, or teammates can use the same layers and outputs without copying files between machines
+- **Durable object storage** — rasters, shapefiles, and downloads survive container restarts and host replacement (no reliance on ephemeral container disks)
+- **Fits cloud deployments** — natural choice when GIS MCP runs on GCE, GKE, Cloud Run, or other GCP workloads next to your data lake / pipeline buckets
+- **Scalable data volume** — large imagery and climate downloads are not limited by a single VM disk; you pay for objects you store
+- **Clear separation** — keep tool working files under a bucket prefix (e.g. `gis-data/`) while apps and pipelines read/write the same objects
+
+**Typical use cases:** multi-user or multi-agent GIS workflows; HTTP-mode servers in the cloud that upload/download via `/storage/*`; keeping satellite, climate, or movement downloads in a project bucket; handing analysis outputs to downstream GCP jobs (BigQuery loaders, Dataflow, another service).
 
 ### Install
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ theme:
 nav:
   - HOME: index.md
   - Getting Started: getting-started.md
+  - Architecture: architecture.md
   - Vibe Coding: vibe-coding.md
   - DOCUMENTATIONS:
       - Installations:
@@ -171,4 +172,8 @@ markdown_extensions:
   - admonition
   - pymdownx.details
   - pymdownx.highlight
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gis-mcp"
-version = "0.14.0"
+version = "0.15.0"
 description = "A Model Context Protocol (MCP) server implementation for GIS operations using GIS libraries"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -86,6 +86,10 @@ visualize = [
     "pydeck>=0.9.0",
 ]
 
+gcp = [
+    "google-cloud-storage>=2.14.0",
+]
+
 test = [
     "pytest>=7.4.0",
     "pytest-cov>=4.1.0",
@@ -104,6 +108,7 @@ all = [
     "requests>=2.31",
     "folium>=0.15.0",
     "pydeck>=0.9.0",
+    "google-cloud-storage>=2.14.0",
 ]
 
 [project.scripts]

--- a/src/gis_mcp/__init__.py
+++ b/src/gis_mcp/__init__.py
@@ -1,6 +1,6 @@
 """GIS MCP Server - A Model Context Protocol server for GIS operations."""
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"
 
 from .geopandas_functions import *
 from .shapely_functions import *

--- a/src/gis_mcp/main.py
+++ b/src/gis_mcp/main.py
@@ -9,8 +9,9 @@ import logging
 import argparse
 import sys
 import os
+import json
 from .mcp import gis_mcp
-from .storage_config import initialize_storage
+from .storage_config import initialize_storage, parse_storage_config_arg, get_storage_adapter
 try:
     from .data import administrative_boundaries
 except ImportError as e:
@@ -92,8 +93,17 @@ def main():
     # Parse command-line arguments
     parser = argparse.ArgumentParser(description="GIS MCP Server")
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
-    parser.add_argument("--storage-path", type=str, default=None, 
+    parser.add_argument("--storage-path", type=str, default=None,
                        help="Path to storage folder for file operations (default: ~/.gis_mcp/data/)")
+    parser.add_argument(
+        "--storage-config",
+        type=str,
+        default=None,
+        help=(
+            'JSON object or path to JSON file configuring storage backend, e.g. '
+            '\'{"provider":"gcp","bucket":"my-bucket","prefix":"gis-data/"}\''
+        ),
+    )
     args = parser.parse_args()
     
     # Set logging level
@@ -101,11 +111,35 @@ def main():
         logging.getLogger().setLevel(logging.DEBUG)
         logger.debug("Debug logging enabled")
     
-    # Initialize storage configuration
-    # Check environment variable first, then command-line argument
-    storage_config = os.getenv('GIS_MCP_STORAGE_PATH', args.storage_path)
-    storage_path = initialize_storage(storage_config)
-    logger.info(f"Storage path initialized: {storage_path}")
+    # Initialize storage configuration.
+    # Priority:
+    #   1. --storage-config
+    #   2. GIS_MCP_STORAGE_CONFIG / GIS_MCP_STORAGE_PROVIDER env
+    #   3. GIS_MCP_STORAGE_PATH env (overrides --storage-path)
+    #   4. --storage-path
+    #   5. default ~/.gis_mcp/data/
+    try:
+        cli_storage_config = parse_storage_config_arg(args.storage_config)
+    except (ValueError, json.JSONDecodeError) as e:
+        logger.error(f"Invalid --storage-config: {e}")
+        sys.exit(1)
+
+    if cli_storage_config is not None:
+        storage_config = cli_storage_config
+    elif os.getenv("GIS_MCP_STORAGE_CONFIG") or os.getenv("GIS_MCP_STORAGE_PROVIDER"):
+        storage_config = None  # initialize_storage reads structured env config
+    else:
+        storage_config = os.getenv("GIS_MCP_STORAGE_PATH", args.storage_path)
+
+    try:
+        storage_path = initialize_storage(storage_config)
+    except (ValueError, ImportError, FileNotFoundError) as e:
+        logger.error(f"Failed to initialize storage: {e}")
+        sys.exit(1)
+
+    adapter = get_storage_adapter()
+    logger.info(f"Storage initialized ({adapter.describe()})")
+    logger.info(f"Local storage path: {storage_path}")
     
     # Get transport configuration from environment variables
     transport = os.getenv('GIS_MCP_TRANSPORT', 'stdio').lower()

--- a/src/gis_mcp/storage/__init__.py
+++ b/src/gis_mcp/storage/__init__.py
@@ -1,0 +1,25 @@
+"""Storage adapters for local filesystem and cloud backends."""
+
+from .base import StorageAdapter, StorageEntry
+from .local import LocalStorageAdapter
+
+__all__ = [
+    "StorageAdapter",
+    "StorageEntry",
+    "LocalStorageAdapter",
+    "GCPStorageAdapter",
+    "create_storage_adapter",
+]
+
+
+def __getattr__(name: str):
+    # Lazy import so google-cloud-storage is only required when GCP is used.
+    if name == "GCPStorageAdapter":
+        from .gcp import GCPStorageAdapter
+
+        return GCPStorageAdapter
+    if name == "create_storage_adapter":
+        from .factory import create_storage_adapter
+
+        return create_storage_adapter
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/gis_mcp/storage/base.py
+++ b/src/gis_mcp/storage/base.py
@@ -1,0 +1,79 @@
+"""Abstract storage adapter interface."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+
+@dataclass
+class StorageEntry:
+    """Metadata for a file or directory in storage."""
+
+    name: str
+    path: str
+    type: str  # "file" or "directory"
+    size: Optional[int] = None
+    modified: Optional[float] = None
+
+
+class StorageAdapter(ABC):
+    """Interface for reading and writing files in a storage backend."""
+
+    provider: str = "base"
+
+    @abstractmethod
+    def write_bytes(self, path: str, data: bytes) -> str:
+        """Write bytes to ``path`` (relative to storage root). Returns the stored path."""
+
+    @abstractmethod
+    def read_bytes(self, path: str) -> bytes:
+        """Read bytes from ``path``."""
+
+    @abstractmethod
+    def exists(self, path: str = "") -> bool:
+        """Return True if the path exists."""
+
+    @abstractmethod
+    def is_file(self, path: str) -> bool:
+        """Return True if the path is a file."""
+
+    @abstractmethod
+    def is_dir(self, path: str = "") -> bool:
+        """Return True if the path is a directory (or storage root)."""
+
+    @abstractmethod
+    def list_dir(self, path: str = "") -> List[StorageEntry]:
+        """List immediate children of a directory."""
+
+    @abstractmethod
+    def ensure_dir(self, path: str) -> None:
+        """Create a directory (and parents) if needed."""
+
+    @abstractmethod
+    def get_local_root(self) -> Path:
+        """
+        Return a local filesystem root for GIS libraries that need real paths.
+
+        Cloud adapters may use a local cache directory and sync as needed.
+        """
+
+    def resolve_local_path(self, file_path: str, relative_to_storage: bool = True) -> Path:
+        """
+        Resolve ``file_path`` to a local Path.
+
+        Absolute paths are returned as-is. Relative paths are joined to the
+        local storage root when ``relative_to_storage`` is True.
+        """
+        path = Path(file_path)
+        if path.is_absolute():
+            return path.expanduser().resolve()
+        if relative_to_storage:
+            return (self.get_local_root() / path).resolve()
+        return path.expanduser().resolve()
+
+    def describe(self) -> str:
+        """Human-readable description of this storage backend."""
+        return f"{self.provider}:{self.get_local_root()}"

--- a/src/gis_mcp/storage/factory.py
+++ b/src/gis_mcp/storage/factory.py
@@ -1,0 +1,88 @@
+"""Factory for creating storage adapters from configuration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+from .base import StorageAdapter
+from .local import LocalStorageAdapter
+
+
+def _as_dict(config: Union[str, Dict[str, Any], Path, None]) -> Optional[Dict[str, Any]]:
+    """Normalize config input into a dict, or None for default local storage."""
+    if config is None:
+        return None
+
+    if isinstance(config, dict):
+        return config
+
+    if isinstance(config, Path):
+        config = str(config)
+
+    if isinstance(config, str):
+        text = config.strip()
+        if not text:
+            return None
+        # JSON object → structured storage config
+        if text.startswith("{"):
+            try:
+                parsed = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"Invalid storage_config JSON: {exc}"
+                ) from exc
+            if not isinstance(parsed, dict):
+                raise ValueError("storage_config JSON must be an object")
+            return parsed
+        # Plain path string → local filesystem (backward compatible)
+        return {"provider": "local", "path": text}
+
+    raise TypeError(f"Unsupported storage_config type: {type(config)!r}")
+
+
+def create_storage_adapter(
+    config: Union[str, Dict[str, Any], Path, None] = None,
+) -> StorageAdapter:
+    """
+    Create a storage adapter from configuration.
+
+    Supported forms:
+    - None → default local path (~/.gis_mcp/data/)
+    - "/some/path" or {"provider": "local", "path": "..."} → local filesystem
+    - {"provider": "gcp", "bucket": "...", "prefix": "...", ...} → GCS
+    """
+    cfg = _as_dict(config)
+    if cfg is None:
+        return LocalStorageAdapter()
+
+    provider = str(cfg.get("provider", "local")).lower().strip()
+
+    if provider in ("local", "filesystem", "fs"):
+        path = cfg.get("path") or cfg.get("storage_path")
+        return LocalStorageAdapter(Path(path) if path else None)
+
+    if provider in ("gcp", "gcs", "google", "google_cloud_storage"):
+        from .gcp import GCPStorageAdapter
+
+        bucket = cfg.get("bucket") or cfg.get("bucket_name")
+        if not bucket:
+            raise ValueError(
+                "GCP storage_config requires a 'bucket' field, e.g. "
+                '{"provider": "gcp", "bucket": "my-bucket"}'
+            )
+        return GCPStorageAdapter(
+            bucket=str(bucket),
+            prefix=str(cfg.get("prefix", "") or ""),
+            credentials=cfg.get("credentials")
+            or cfg.get("credentials_path")
+            or cfg.get("key_file"),
+            project=cfg.get("project"),
+            local_cache=Path(cfg["local_cache"]) if cfg.get("local_cache") else None,
+        )
+
+    raise ValueError(
+        f"Unsupported storage provider: {provider!r}. "
+        'Supported providers: "local", "gcp".'
+    )

--- a/src/gis_mcp/storage/gcp.py
+++ b/src/gis_mcp/storage/gcp.py
@@ -1,0 +1,279 @@
+"""Google Cloud Storage adapter."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import List, Optional, Union
+
+from .base import StorageAdapter, StorageEntry
+
+logger = logging.getLogger("gis-mcp")
+
+
+class GCPStorageAdapter(StorageAdapter):
+    """
+    Store files in a Google Cloud Storage bucket.
+
+    A local cache under ``~/.gis_mcp/gcp_cache/<bucket>/`` is used so GIS
+    libraries that require real filesystem paths continue to work. Storage
+    HTTP endpoints read and write the bucket directly.
+    """
+
+    provider = "gcp"
+
+    def __init__(
+        self,
+        bucket: str,
+        prefix: str = "",
+        credentials: Optional[Union[str, Path]] = None,
+        project: Optional[str] = None,
+        local_cache: Optional[Path] = None,
+        client=None,
+    ):
+        if not bucket:
+            raise ValueError("GCP storage requires a non-empty 'bucket' value")
+
+        self.bucket_name = bucket
+        self.prefix = self._normalize_prefix(prefix)
+        self.credentials_path = (
+            str(Path(credentials).expanduser()) if credentials else None
+        )
+        self.project = project
+
+        if client is not None:
+            self._client = client
+        else:
+            try:
+                from google.cloud import storage as gcs  # type: ignore
+            except ImportError as exc:
+                raise ImportError(
+                    "google-cloud-storage is required for GCP storage. "
+                    "Install with: pip install gis-mcp[gcp]"
+                ) from exc
+            self._client = self._build_client(gcs)
+
+        self._bucket = self._client.bucket(self.bucket_name)
+
+        if local_cache is None:
+            local_cache = (
+                Path.home() / ".gis_mcp" / "gcp_cache" / self.bucket_name
+            )
+        self._local_root = Path(local_cache).expanduser().resolve()
+        self._local_root.mkdir(parents=True, exist_ok=True)
+
+        logger.info(
+            "GCP storage initialized: gs://%s/%s (cache: %s)",
+            self.bucket_name,
+            self.prefix,
+            self._local_root,
+        )
+
+    @staticmethod
+    def _normalize_prefix(prefix: str) -> str:
+        prefix = (prefix or "").replace("\\", "/").lstrip("/")
+        if prefix and not prefix.endswith("/"):
+            prefix += "/"
+        return prefix
+
+    def _build_client(self, gcs_module):
+        """
+        Build a GCS client using (in order):
+        1. Explicit credentials key file from config
+        2. GOOGLE_APPLICATION_CREDENTIALS / Application Default Credentials
+        """
+        if self.credentials_path:
+            if not Path(self.credentials_path).is_file():
+                raise FileNotFoundError(
+                    f"GCP credentials file not found: {self.credentials_path}"
+                )
+            return gcs_module.Client.from_service_account_json(
+                self.credentials_path,
+                project=self.project,
+            )
+
+        # Env var GOOGLE_APPLICATION_CREDENTIALS or other ADC sources
+        env_creds = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+        if env_creds:
+            logger.debug(
+                "Using GOOGLE_APPLICATION_CREDENTIALS=%s", env_creds
+            )
+        return gcs_module.Client(project=self.project)
+
+    def get_local_root(self) -> Path:
+        return self._local_root
+
+    def _blob_name(self, path: str) -> str:
+        clean = str(path or "").lstrip("/").replace("\\", "/")
+        return f"{self.prefix}{clean}" if clean else self.prefix.rstrip("/")
+
+    def _local_path(self, path: str) -> Path:
+        clean = str(path or "").lstrip("/").replace("\\", "/")
+        if not clean:
+            return self._local_root
+        return (self._local_root / clean).resolve()
+
+    def write_bytes(self, path: str, data: bytes) -> str:
+        clean = str(path).lstrip("/").replace("\\", "/")
+        blob = self._bucket.blob(self._blob_name(clean))
+        blob.upload_from_string(data)
+
+        # Keep local cache in sync for GIS tool usage
+        local = self._local_path(clean)
+        local.parent.mkdir(parents=True, exist_ok=True)
+        local.write_bytes(data)
+        return clean
+
+    def read_bytes(self, path: str) -> bytes:
+        clean = str(path).lstrip("/").replace("\\", "/")
+        blob = self._bucket.blob(self._blob_name(clean))
+        if not blob.exists():
+            raise FileNotFoundError(f"File not found in GCS: {clean}")
+        data = blob.download_as_bytes()
+
+        local = self._local_path(clean)
+        local.parent.mkdir(parents=True, exist_ok=True)
+        local.write_bytes(data)
+        return data
+
+    def exists(self, path: str = "") -> bool:
+        clean = str(path or "").lstrip("/").replace("\\", "/")
+        if not clean:
+            return True
+
+        blob_name = self._blob_name(clean)
+        blob = self._bucket.blob(blob_name)
+        if blob.exists():
+            return True
+
+        # Treat prefix as a directory if any objects exist under it
+        prefix = blob_name if blob_name.endswith("/") else f"{blob_name}/"
+        return any(self._client.list_blobs(self.bucket_name, prefix=prefix, max_results=1))
+
+    def is_file(self, path: str) -> bool:
+        clean = str(path).lstrip("/").replace("\\", "/")
+        if not clean:
+            return False
+        return self._bucket.blob(self._blob_name(clean)).exists()
+
+    def is_dir(self, path: str = "") -> bool:
+        clean = str(path or "").lstrip("/").replace("\\", "/")
+        if not clean:
+            return True
+        if self.is_file(clean):
+            return False
+        prefix = self._blob_name(clean)
+        if not prefix.endswith("/"):
+            prefix += "/"
+        return any(
+            self._client.list_blobs(self.bucket_name, prefix=prefix, max_results=1)
+        )
+
+    def ensure_dir(self, path: str) -> None:
+        # GCS has no real directories; ensure local cache dir exists.
+        self._local_path(path).mkdir(parents=True, exist_ok=True)
+
+    def list_dir(self, path: str = "") -> List[StorageEntry]:
+        clean = str(path or "").lstrip("/").replace("\\", "/")
+
+        if clean and self.is_file(clean):
+            blob = self._bucket.blob(self._blob_name(clean))
+            blob.reload()
+            return [
+                StorageEntry(
+                    name=Path(clean).name,
+                    path=clean,
+                    type="file",
+                    size=blob.size,
+                    modified=blob.updated.timestamp() if blob.updated else None,
+                )
+            ]
+
+        if clean and not self.exists(clean):
+            raise FileNotFoundError(f"Path not found: {clean or 'root'}")
+
+        list_prefix = self._blob_name(clean)
+        if list_prefix and not list_prefix.endswith("/"):
+            list_prefix += "/"
+        # Empty path with empty prefix → list from bucket root / configured prefix
+        if not clean:
+            list_prefix = self.prefix
+
+        iterator = self._client.list_blobs(
+            self.bucket_name,
+            prefix=list_prefix,
+            delimiter="/",
+        )
+        # Consume iterator so prefixes (directories) are populated
+        blobs = list(iterator)
+        prefixes = list(iterator.prefixes) if iterator.prefixes else []
+
+        entries: List[StorageEntry] = []
+        seen_names = set()
+
+        for prefix in prefixes:
+            # Strip storage prefix and list prefix to get relative directory name
+            relative = prefix
+            if self.prefix and relative.startswith(self.prefix):
+                relative = relative[len(self.prefix) :]
+            relative = relative.rstrip("/")
+            if clean:
+                # Child relative to requested path
+                if relative.startswith(clean + "/"):
+                    name = relative[len(clean) + 1 :].split("/")[0]
+                elif relative == clean:
+                    continue
+                else:
+                    name = relative.split("/")[-1]
+            else:
+                name = relative.split("/")[0] if relative else ""
+            if not name or name in seen_names:
+                continue
+            child_path = f"{clean}/{name}" if clean else name
+            entries.append(
+                StorageEntry(
+                    name=name,
+                    path=child_path,
+                    type="directory",
+                    size=None,
+                    modified=None,
+                )
+            )
+            seen_names.add(name)
+
+        for blob in blobs:
+            name = blob.name
+            if self.prefix and name.startswith(self.prefix):
+                name = name[len(self.prefix) :]
+            # Skip the directory placeholder itself
+            if not name or name.endswith("/"):
+                continue
+            if clean:
+                if not name.startswith(clean + "/"):
+                    continue
+                remainder = name[len(clean) + 1 :]
+            else:
+                remainder = name
+            # Only immediate children
+            if "/" in remainder:
+                continue
+            if not remainder or remainder in seen_names:
+                continue
+            child_path = f"{clean}/{remainder}" if clean else remainder
+            entries.append(
+                StorageEntry(
+                    name=remainder,
+                    path=child_path,
+                    type="file",
+                    size=blob.size,
+                    modified=blob.updated.timestamp() if blob.updated else None,
+                )
+            )
+            seen_names.add(remainder)
+
+        entries.sort(key=lambda e: (e.type != "directory", e.name.lower()))
+        return entries
+
+    def describe(self) -> str:
+        return f"gcp:gs://{self.bucket_name}/{self.prefix}"

--- a/src/gis_mcp/storage/local.py
+++ b/src/gis_mcp/storage/local.py
@@ -1,0 +1,90 @@
+"""Local filesystem storage adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional
+
+from .base import StorageAdapter, StorageEntry
+
+
+class LocalStorageAdapter(StorageAdapter):
+    """Store files on the local filesystem."""
+
+    provider = "local"
+
+    def __init__(self, root: Optional[Path] = None):
+        if root is None:
+            root = Path.home() / ".gis_mcp" / "data"
+        self._root = Path(root).expanduser().resolve()
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    def get_local_root(self) -> Path:
+        return self._root
+
+    def _resolve(self, path: str = "") -> Path:
+        clean = str(path or "").lstrip("/").replace("\\", "/")
+        if not clean:
+            return self._root
+        return (self._root / clean).resolve()
+
+    def write_bytes(self, path: str, data: bytes) -> str:
+        target = self._resolve(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+        return str(path).lstrip("/").replace("\\", "/")
+
+    def read_bytes(self, path: str) -> bytes:
+        target = self._resolve(path)
+        if not target.is_file():
+            raise FileNotFoundError(f"File not found: {path}")
+        return target.read_bytes()
+
+    def exists(self, path: str = "") -> bool:
+        return self._resolve(path).exists()
+
+    def is_file(self, path: str) -> bool:
+        return self._resolve(path).is_file()
+
+    def is_dir(self, path: str = "") -> bool:
+        return self._resolve(path).is_dir()
+
+    def ensure_dir(self, path: str) -> None:
+        self._resolve(path).mkdir(parents=True, exist_ok=True)
+
+    def list_dir(self, path: str = "") -> List[StorageEntry]:
+        target = self._resolve(path)
+        if not target.exists():
+            raise FileNotFoundError(f"Path not found: {path or 'root'}")
+
+        if target.is_file():
+            stat = target.stat()
+            clean = str(path).lstrip("/").replace("\\", "/")
+            return [
+                StorageEntry(
+                    name=target.name,
+                    path=clean,
+                    type="file",
+                    size=stat.st_size,
+                    modified=stat.st_mtime,
+                )
+            ]
+
+        entries: List[StorageEntry] = []
+        for item in target.iterdir():
+            stat = item.stat()
+            relative = item.relative_to(self._root)
+            entries.append(
+                StorageEntry(
+                    name=item.name,
+                    path=str(relative).replace("\\", "/"),
+                    type="file" if item.is_file() else "directory",
+                    size=stat.st_size if item.is_file() else None,
+                    modified=stat.st_mtime,
+                )
+            )
+        entries.sort(key=lambda e: (e.type != "directory", e.name.lower()))
+        return entries
+
+    def describe(self) -> str:
+        return f"local:{self._root}"

--- a/src/gis_mcp/storage_config.py
+++ b/src/gis_mcp/storage_config.py
@@ -1,99 +1,188 @@
 """
 Storage configuration for GIS MCP Server.
 
-This module manages the storage path for file operations, allowing users
-to specify a custom folder or use a default location.
+Supports local filesystem (default) and optional cloud backends such as GCP.
+Backward compatible with ``--storage-path`` / ``GIS_MCP_STORAGE_PATH``.
 """
 
+from __future__ import annotations
+
+import json
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, Optional, Union
 
-# Global storage path - will be initialized on server startup
+from .storage.base import StorageAdapter
+from .storage.factory import create_storage_adapter
+from .storage.local import LocalStorageAdapter
+
+# Global storage state — initialized on server startup
+_storage_adapter: Optional[StorageAdapter] = None
 _storage_path: Optional[Path] = None
 
 
 def get_default_storage_path() -> Path:
     """
     Get the default storage path: ~/.gis_mcp/data/
-    
+
     Returns:
         Path object pointing to the default storage directory
     """
-    home = Path.home()
-    default_path = home / ".gis_mcp" / "data"
-    return default_path
+    return Path.home() / ".gis_mcp" / "data"
 
 
-def initialize_storage(storage_config: Optional[str] = None) -> Path:
+def _load_config_from_env_and_args(
+    storage_config: Optional[Union[str, Dict[str, Any]]] = None,
+) -> Optional[Union[str, Dict[str, Any]]]:
+    """
+    Resolve storage configuration from (highest priority first):
+    1. Explicit ``storage_config`` argument (dict or JSON/path string)
+    2. ``GIS_MCP_STORAGE_CONFIG`` environment variable (JSON)
+    3. Discrete GCP env vars (``GIS_MCP_STORAGE_PROVIDER=gcp``, ...)
+    4. ``GIS_MCP_STORAGE_PATH`` / plain path string (local)
+    """
+    if storage_config is not None:
+        return storage_config
+
+    env_json = os.getenv("GIS_MCP_STORAGE_CONFIG")
+    if env_json:
+        return env_json
+
+    provider = (os.getenv("GIS_MCP_STORAGE_PROVIDER") or "").lower().strip()
+    if provider in ("gcp", "gcs", "google", "google_cloud_storage"):
+        bucket = os.getenv("GIS_MCP_GCS_BUCKET") or os.getenv("GIS_MCP_GCP_BUCKET")
+        if not bucket:
+            raise ValueError(
+                "GIS_MCP_STORAGE_PROVIDER=gcp requires GIS_MCP_GCS_BUCKET "
+                "(or GIS_MCP_GCP_BUCKET) to be set"
+            )
+        cfg: Dict[str, Any] = {
+            "provider": "gcp",
+            "bucket": bucket,
+            "prefix": os.getenv("GIS_MCP_GCS_PREFIX")
+            or os.getenv("GIS_MCP_GCP_PREFIX")
+            or "",
+        }
+        creds = (
+            os.getenv("GIS_MCP_GCS_CREDENTIALS")
+            or os.getenv("GIS_MCP_GCP_CREDENTIALS")
+        )
+        if creds:
+            cfg["credentials"] = creds
+        project = os.getenv("GIS_MCP_GCS_PROJECT") or os.getenv("GIS_MCP_GCP_PROJECT")
+        if project:
+            cfg["project"] = project
+        return cfg
+
+    env_path = os.getenv("GIS_MCP_STORAGE_PATH")
+    if env_path:
+        return env_path
+
+    return None
+
+
+def initialize_storage(
+    storage_config: Optional[Union[str, Dict[str, Any]]] = None,
+) -> Path:
     """
     Initialize the storage configuration.
-    
-    If storage_config is provided, use that path. Otherwise, use the default.
-    Creates the directory if it doesn't exist.
-    
+
     Args:
-        storage_config: Optional path to the storage folder. If None, uses default.
-        
+        storage_config: One of:
+            - None: use env vars or default local path
+            - str path: local filesystem (``--storage-path`` behavior)
+            - JSON str / dict with ``"provider": "local"|"gcp"``
+
     Returns:
-        Path object pointing to the storage directory
+        Path to the local storage root (or local cache for cloud backends)
     """
-    global _storage_path
-    
-    if storage_config:
-        storage_path = Path(storage_config).expanduser().resolve()
-    else:
-        storage_path = get_default_storage_path()
-    
-    # Create directory if it doesn't exist
-    storage_path.mkdir(parents=True, exist_ok=True)
-    
-    _storage_path = storage_path
-    return storage_path
+    global _storage_adapter, _storage_path
+
+    resolved = _load_config_from_env_and_args(storage_config)
+    adapter = create_storage_adapter(resolved)
+
+    _storage_adapter = adapter
+    _storage_path = adapter.get_local_root()
+    return _storage_path
+
+
+def get_storage_adapter() -> StorageAdapter:
+    """
+    Get the active storage adapter.
+
+    Initializes default local storage if not already initialized.
+    """
+    global _storage_adapter, _storage_path
+
+    if _storage_adapter is None:
+        initialize_storage()
+    assert _storage_adapter is not None
+    return _storage_adapter
 
 
 def get_storage_path() -> Path:
     """
-    Get the current storage path.
-    
-    If not initialized, initializes with default path.
-    
-    Returns:
-        Path object pointing to the storage directory
+    Get the current local storage path.
+
+    For cloud backends this is the local cache directory used by GIS tools.
+    If not initialized, initializes with the default path.
     """
     global _storage_path
-    
+
     if _storage_path is None:
-        _storage_path = initialize_storage()
-    
+        initialize_storage()
+    assert _storage_path is not None
     return _storage_path
 
 
 def resolve_path(file_path: str, relative_to_storage: bool = True) -> Path:
     """
     Resolve a file path, optionally making it relative to the storage directory.
-    
-    If the path is absolute, it's used as-is. If relative and relative_to_storage
-    is True, it's resolved relative to the storage directory.
-    
-    Args:
-        file_path: The file path to resolve
-        relative_to_storage: If True and path is relative, resolve relative to storage
-        
-    Returns:
-        Resolved Path object
-    """
-    path = Path(file_path)
-    
-    # If absolute path, use as-is
-    if path.is_absolute():
-        return path.expanduser().resolve()
-    
-    # If relative and we should use storage, resolve relative to storage
-    if relative_to_storage:
-        storage = get_storage_path()
-        return (storage / path).resolve()
-    
-    # Otherwise, resolve relative to current working directory
-    return path.expanduser().resolve()
 
+    If the path is absolute, it's used as-is. If relative and relative_to_storage
+    is True, it's resolved relative to the storage directory (or GCP local cache).
+    """
+    return get_storage_adapter().resolve_local_path(
+        file_path, relative_to_storage=relative_to_storage
+    )
+
+
+def parse_storage_config_arg(value: Optional[str]) -> Optional[Union[str, Dict[str, Any]]]:
+    """
+    Parse a CLI ``--storage-config`` value.
+
+    Accepts a JSON object string or a path to a JSON file. Returns None if empty.
+    """
+    if value is None:
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    if text.startswith("{"):
+        parsed = json.loads(text)
+        if not isinstance(parsed, dict):
+            raise ValueError("--storage-config JSON must be an object")
+        return parsed
+    path = Path(text).expanduser()
+    if path.is_file():
+        with path.open("r", encoding="utf-8") as fh:
+            parsed = json.load(fh)
+        if not isinstance(parsed, dict):
+            raise ValueError("storage config file must contain a JSON object")
+        return parsed
+    raise ValueError(
+        f"--storage-config must be a JSON object or path to a JSON file: {value}"
+    )
+
+
+# Re-export for convenience / typing
+__all__ = [
+    "get_default_storage_path",
+    "initialize_storage",
+    "get_storage_adapter",
+    "get_storage_path",
+    "resolve_path",
+    "parse_storage_config_arg",
+    "StorageAdapter",
+    "LocalStorageAdapter",
+]

--- a/src/gis_mcp/storage_endpoints.py
+++ b/src/gis_mcp/storage_endpoints.py
@@ -2,18 +2,20 @@
 Storage HTTP endpoints for GIS MCP Server.
 
 This module provides HTTP endpoints for file upload, download, and listing
-operations when the server runs in HTTP/SSE transport mode.
+operations when the server runs in HTTP/SSE transport mode. Operations go
+through the configured storage adapter (local filesystem or GCP).
 """
 
+import io
 import logging
-from pathlib import Path
-from typing import Optional, Dict, Any, List
+from typing import Optional
+
 from starlette.requests import Request
-from starlette.responses import JSONResponse, FileResponse, StreamingResponse
+from starlette.responses import JSONResponse, StreamingResponse
 from starlette.datastructures import UploadFile
 
 from .mcp import gis_mcp
-from .storage_config import get_storage_path, resolve_path
+from .storage_config import get_storage_adapter
 
 logger = logging.getLogger("gis-mcp")
 
@@ -22,121 +24,132 @@ logger = logging.getLogger("gis-mcp")
 async def upload_file(request: Request) -> JSONResponse:
     """
     Upload a file to remote storage.
-    
+
     Expected request:
     - Content-Type: multipart/form-data
     - Fields: 'file' (file data), 'path' (optional remote path)
-    
+
     Returns JSON with:
     - remote_path: Path where file was saved
     - size: File size in bytes
     - message: Success message
     """
     try:
-        # Parse multipart form data
         form = await request.form()
-        
-        # Get file from form
+
         if "file" not in form:
             return JSONResponse(
                 {"error": "Missing 'file' field in form data"},
-                status_code=400
+                status_code=400,
             )
-        
+
         file_item = form["file"]
         if not isinstance(file_item, UploadFile):
             return JSONResponse(
                 {"error": "Invalid file field"},
-                status_code=400
+                status_code=400,
             )
-        
-        # Get optional remote path
+
         remote_path = form.get("path")
         if remote_path is None:
             remote_path = file_item.filename or "uploaded_file"
-        
-        # Clean up path (remove leading slash)
-        remote_path = str(remote_path).lstrip('/')
-        
-        # Resolve path relative to storage directory
-        target_path = resolve_path(remote_path, relative_to_storage=True)
-        target_path.parent.mkdir(parents=True, exist_ok=True)
-        
-        # Save file
+
+        remote_path = str(remote_path).lstrip("/")
+        adapter = get_storage_adapter()
+
+        # Ensure parent "directory" exists for local / cache backends
+        parent = "/".join(remote_path.split("/")[:-1])
+        if parent:
+            adapter.ensure_dir(parent)
+
         file_content = await file_item.read()
-        target_path.write_bytes(file_content)
-        
+        stored_path = adapter.write_bytes(remote_path, file_content)
         file_size = len(file_content)
-        
-        logger.info(f"File uploaded: {remote_path} -> {target_path} ({file_size} bytes)")
-        
-        # Return response matching client expectations
-        return JSONResponse({
-            "remote_path": remote_path,
-            "size": file_size,
-            "message": f"File uploaded successfully to {remote_path}"
-        })
-        
+
+        logger.info(
+            "File uploaded: %s (%s bytes) via %s",
+            stored_path,
+            file_size,
+            adapter.describe(),
+        )
+
+        return JSONResponse(
+            {
+                "remote_path": stored_path,
+                "size": file_size,
+                "message": f"File uploaded successfully to {stored_path}",
+            }
+        )
+
     except Exception as e:
         logger.error(f"Error uploading file: {str(e)}", exc_info=True)
         return JSONResponse(
             {"error": str(e), "message": f"Failed to upload file: {str(e)}"},
-            status_code=500
+            status_code=500,
         )
 
 
 @gis_mcp.custom_route("/storage/download", methods=["GET"])
-async def download_file(request: Request) -> FileResponse:
+async def download_file(request: Request):
     """
     Download a file from remote storage.
-    
+
     Query parameters:
     - path: Path to the file to download (required)
-    
+
     Returns the file content with appropriate Content-Type.
     """
     try:
-        # Get path from query parameters
         path_param = request.query_params.get("path")
         if not path_param:
             return JSONResponse(
                 {"error": "Missing 'path' query parameter"},
-                status_code=400
+                status_code=400,
             )
-        
-        # Clean up path
-        remote_path = str(path_param).lstrip('/')
-        
-        # Resolve path relative to storage directory
-        file_path = resolve_path(remote_path, relative_to_storage=True)
-        
-        # Check if file exists
-        if not file_path.exists():
+
+        remote_path = str(path_param).lstrip("/")
+        adapter = get_storage_adapter()
+
+        if not adapter.exists(remote_path):
             return JSONResponse(
                 {"error": f"File not found: {remote_path}"},
-                status_code=404
+                status_code=404,
             )
-        
-        if not file_path.is_file():
+
+        if not adapter.is_file(remote_path):
             return JSONResponse(
                 {"error": f"Path is not a file: {remote_path}"},
-                status_code=400
+                status_code=400,
             )
-        
-        logger.info(f"File download requested: {remote_path} -> {file_path}")
-        
-        # Return file as response
-        return FileResponse(
-            path=str(file_path),
-            filename=file_path.name,
-            media_type="application/octet-stream"
+
+        data = adapter.read_bytes(remote_path)
+        filename = remote_path.split("/")[-1] or "download"
+
+        logger.info(
+            "File download requested: %s via %s",
+            remote_path,
+            adapter.describe(),
         )
-        
+
+        return StreamingResponse(
+            io.BytesIO(data),
+            media_type="application/octet-stream",
+            headers={
+                "Content-Disposition": f'attachment; filename="{filename}"',
+                "Content-Length": str(len(data)),
+            },
+        )
+
+    except FileNotFoundError as e:
+        return JSONResponse(
+            {"error": str(e)},
+            status_code=404,
+        )
     except Exception as e:
         logger.error(f"Error downloading file: {str(e)}", exc_info=True)
         return JSONResponse(
             {"error": str(e), "message": f"Failed to download file: {str(e)}"},
-            status_code=500
+            status_code=500,
         )
 
 
@@ -144,78 +157,60 @@ async def download_file(request: Request) -> FileResponse:
 async def list_files(request: Request) -> JSONResponse:
     """
     List files in remote storage.
-    
+
     Query parameters:
     - path: Optional directory path to list (defaults to storage root)
-    
+
     Returns JSON with:
     - files: List of file/directory information
     - path: The path that was listed
     """
     try:
-        # Get optional path from query parameters
         path_param = request.query_params.get("path")
-        
-        if path_param:
-            remote_path = str(path_param).lstrip('/')
-            target_path = resolve_path(remote_path, relative_to_storage=True)
-        else:
-            remote_path = ""
-            target_path = get_storage_path()
-        
-        # Check if path exists
-        if not target_path.exists():
+        remote_path = str(path_param).lstrip("/") if path_param else ""
+        adapter = get_storage_adapter()
+
+        try:
+            entries = adapter.list_dir(remote_path)
+        except FileNotFoundError:
             return JSONResponse(
                 {"error": f"Path not found: {remote_path or 'root'}"},
-                status_code=404
+                status_code=404,
             )
-        
-        # If it's a file, return just that file
-        if target_path.is_file():
-            stat = target_path.stat()
-            return JSONResponse({
-                "files": [{
-                    "name": target_path.name,
-                    "path": remote_path,
-                    "size": stat.st_size,
-                    "type": "file",
-                    "modified": stat.st_mtime
-                }],
-                "path": remote_path or "/"
-            })
-        
-        # If it's a directory, list contents
-        files_list = []
-        try:
-            for item in target_path.iterdir():
-                stat = item.stat()
-                relative_path = item.relative_to(get_storage_path())
-                files_list.append({
-                    "name": item.name,
-                    "path": str(relative_path).replace("\\", "/"),  # Normalize path separators
-                    "size": stat.st_size if item.is_file() else None,
-                    "type": "file" if item.is_file() else "directory",
-                    "modified": stat.st_mtime
-                })
         except PermissionError:
             return JSONResponse(
                 {"error": f"Permission denied: {remote_path or 'root'}"},
-                status_code=403
+                status_code=403,
             )
-        
-        # Sort: directories first, then files, both alphabetically
-        files_list.sort(key=lambda x: (x["type"] != "directory", x["name"].lower()))
-        
-        logger.info(f"Listed {len(files_list)} items in {remote_path or 'root'}")
-        
-        return JSONResponse({
-            "files": files_list,
-            "path": remote_path or "/"
-        })
-        
+
+        files_list = [
+            {
+                "name": entry.name,
+                "path": entry.path,
+                "size": entry.size,
+                "type": entry.type,
+                "modified": entry.modified,
+            }
+            for entry in entries
+        ]
+
+        logger.info(
+            "Listed %s items in %s via %s",
+            len(files_list),
+            remote_path or "root",
+            adapter.describe(),
+        )
+
+        return JSONResponse(
+            {
+                "files": files_list,
+                "path": remote_path or "/",
+            }
+        )
+
     except Exception as e:
         logger.error(f"Error listing files: {str(e)}", exc_info=True)
         return JSONResponse(
             {"error": str(e), "message": f"Failed to list files: {str(e)}"},
-            status_code=500
+            status_code=500,
         )

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,113 @@
+"""Tests for local storage configuration and adapters."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gis_mcp.storage.factory import create_storage_adapter
+from gis_mcp.storage.local import LocalStorageAdapter
+from gis_mcp import storage_config
+
+
+@pytest.fixture(autouse=True)
+def reset_storage_globals():
+    """Reset module-level storage state between tests."""
+    storage_config._storage_adapter = None
+    storage_config._storage_path = None
+    yield
+    storage_config._storage_adapter = None
+    storage_config._storage_path = None
+
+
+@pytest.fixture
+def local_root(tmp_path):
+    return tmp_path / "storage"
+
+
+class TestLocalStorageAdapter:
+    def test_write_read_roundtrip(self, local_root):
+        adapter = LocalStorageAdapter(local_root)
+        path = adapter.write_bytes("outputs/hello.txt", b"hello")
+        assert path == "outputs/hello.txt"
+        assert adapter.read_bytes("outputs/hello.txt") == b"hello"
+        assert adapter.is_file("outputs/hello.txt")
+        assert adapter.exists("outputs")
+
+    def test_list_dir(self, local_root):
+        adapter = LocalStorageAdapter(local_root)
+        adapter.write_bytes("a.txt", b"a")
+        adapter.ensure_dir("subdir")
+        adapter.write_bytes("subdir/b.txt", b"b")
+
+        entries = adapter.list_dir("")
+        names = {e.name: e.type for e in entries}
+        assert names["a.txt"] == "file"
+        assert names["subdir"] == "directory"
+
+    def test_resolve_local_path(self, local_root):
+        adapter = LocalStorageAdapter(local_root)
+        resolved = adapter.resolve_local_path("foo/bar.tif")
+        assert resolved == (local_root.resolve() / "foo" / "bar.tif")
+
+
+class TestCreateStorageAdapter:
+    def test_default_is_local(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        adapter = create_storage_adapter(None)
+        assert isinstance(adapter, LocalStorageAdapter)
+        assert adapter.provider == "local"
+
+    def test_plain_path_string(self, local_root):
+        adapter = create_storage_adapter(str(local_root))
+        assert isinstance(adapter, LocalStorageAdapter)
+        assert adapter.get_local_root() == local_root.resolve()
+
+    def test_local_dict_config(self, local_root):
+        adapter = create_storage_adapter({"provider": "local", "path": str(local_root)})
+        assert isinstance(adapter, LocalStorageAdapter)
+
+    def test_json_string_local(self, local_root):
+        cfg = json.dumps({"provider": "local", "path": str(local_root)})
+        adapter = create_storage_adapter(cfg)
+        assert isinstance(adapter, LocalStorageAdapter)
+
+    def test_unsupported_provider(self):
+        with pytest.raises(ValueError, match="Unsupported storage provider"):
+            create_storage_adapter({"provider": "azure"})
+
+
+class TestInitializeStorage:
+    def test_local_path_backward_compatible(self, local_root):
+        path = storage_config.initialize_storage(str(local_root))
+        assert path == local_root.resolve()
+        assert storage_config.get_storage_path() == path
+        assert storage_config.get_storage_adapter().provider == "local"
+
+    def test_storage_config_env_json(self, local_root, monkeypatch):
+        monkeypatch.setenv(
+            "GIS_MCP_STORAGE_CONFIG",
+            json.dumps({"provider": "local", "path": str(local_root)}),
+        )
+        path = storage_config.initialize_storage(None)
+        assert path == local_root.resolve()
+
+    def test_resolve_path_uses_storage(self, local_root):
+        storage_config.initialize_storage(str(local_root))
+        resolved = storage_config.resolve_path("out/file.tif")
+        assert resolved == (local_root.resolve() / "out" / "file.tif")
+
+    def test_parse_storage_config_arg_json(self):
+        cfg = storage_config.parse_storage_config_arg(
+            '{"provider":"local","path":"/tmp/x"}'
+        )
+        assert cfg == {"provider": "local", "path": "/tmp/x"}
+
+    def test_parse_storage_config_arg_file(self, tmp_path):
+        cfg_file = tmp_path / "storage.json"
+        cfg_file.write_text('{"provider":"local","path":"/tmp/x"}')
+        cfg = storage_config.parse_storage_config_arg(str(cfg_file))
+        assert cfg["provider"] == "local"


### PR DESCRIPTION
## Summary
- Add Google Cloud Storage as a second storage backend (`provider: "gcp"`) via `GCPStorageAdapter`, with local filesystem behavior unchanged for `--storage-path` / `GIS_MCP_STORAGE_PATH`.
- Wire storage adapters into server init and HTTP storage endpoints; support credentials via key file, env, or ADC; optional bucket prefix.
- Document local + GCP (+ Docker) in storage docs, add Architecture page with agentic-role and component diagrams, bump version to **0.15.0**, and refresh README storage badges/section.

## Test plan
- [ ] CI passes on this PR
- [ ] Local storage still works with default path and `--storage-path` / `GIS_MCP_STORAGE_PATH`
- [ ] HTTP `/storage/upload`, `/storage/download`, `/storage/list` work with local storage
- [ ] (Manual) GCP: configure bucket + SA with `roles/storage.objectUser`, run server with `GIS_MCP_STORAGE_PROVIDER=gcp`, verify upload/list/download against the bucket
- [ ] Docs site builds; Architecture and Storage Configuration pages render (including Mermaid)